### PR TITLE
fix(arch/aarch64/iommu): make IOMMU initialization conditional

### DIFF
--- a/src/arch/aarch64/iommu.rs
+++ b/src/arch/aarch64/iommu.rs
@@ -530,7 +530,14 @@ impl Smmuv3 {
 
 static SMMUV3: spin::Once<Mutex<Smmuv3>> = spin::Once::new();
 
-/// smmuv3 init
+/// iommu feature is disabled.
+#[cfg(not(feature = "iommu"))]
+pub fn iommu_init() {
+    info!("aarch64: iommu_init: do nothing now");
+}
+
+/// smmuv3 init (enabled)
+#[cfg(feature = "iommu")]
 pub fn iommu_init() {
     info!("Smmuv3 init...");
     SMMUV3.call_once(|| Mutex::new(Smmuv3::new()));


### PR DESCRIPTION
This commit resolves the issue #212 by wrapping the SMMUv3 initialization logic in a `#[cfg(feature = "iommu")]` attribute. A corresponding empty `iommu_init` function is provided under `#[cfg(not(feature = "iommu"))]`.

This change allows the hypervisor to be compiled without IOMMU support, enabling it to boot successfully on affected hardware by disabling the default feature.

Fixes: #212
