### PR TITLE
feat: add hv_end address output and clarify hvisor memory layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,12 @@ all: clean_check gen_cargo_config $(hvisor_bin)
 	@printf "%-10s %s\n" "RUSTC_TARGET    =" "$(COLOR_BOLD)$(RUSTC_TARGET)$(COLOR_RESET)"
 	@printf "%-10s %s\n" "BUILD_PATH      =" "$(COLOR_BOLD)$(build_path)$(COLOR_RESET)"
 	@printf "%-10s %s\n" "HVISON_BIN_SIZE =" "$(COLOR_BOLD)$(shell du -h $(hvisor_bin) | cut -f1)$(COLOR_RESET)"
+	@start_addr=$$(rust-nm $(hvisor_elf) | grep skernel | awk '{print $$1}'); \
+	 end_addr=$$(rust-nm $(hvisor_elf) | grep __hv_end | awk '{print $$1}'); \
+	 size=$$(printf '%016x\n' $$((0x$$end_addr - 0x$$start_addr))); \
+	 printf "%-10s %s\n" "START_ADDR      =" "$(COLOR_BOLD)0x$$start_addr$(COLOR_RESET)"; \
+	 printf "%-10s %s\n" "MEM_SIZE        =" "$(COLOR_BOLD)0x$$size$(COLOR_RESET)"; \
+	 printf "%-10s %s\n" "END_ADDR        =" "$(COLOR_BOLD)0x$$end_addr$(COLOR_RESET)"
 	@printf "%-10s %s\n" "BUILD TIME      =" "$(COLOR_BOLD)$(shell date)$(COLOR_RESET)"
 	@printf "\n"
 	@printf "$(COLOR_GREEN)$(COLOR_BOLD)hvisor build success!$(COLOR_RESET)\n"

--- a/platform/aarch64/imx8mp/linker.ld
+++ b/platform/aarch64/imx8mp/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/ok6254-c/linker.ld
+++ b/platform/aarch64/ok6254-c/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/phytium-pi/linker.ld
+++ b/platform/aarch64/phytium-pi/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/qemu-gicv2/linker.ld
+++ b/platform/aarch64/qemu-gicv2/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/qemu-gicv3/linker.ld
+++ b/platform/aarch64/qemu-gicv3/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/rk3568/linker.ld
+++ b/platform/aarch64/rk3568/linker.ld
@@ -5,7 +5,7 @@ SECTIONS
 {
     . = BASE_ADDRESS;
     skernel = .;
-    
+
     .boot : {
         *(.text.boot)
         *(.data.boot)
@@ -50,5 +50,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/rk3588/linker.ld
+++ b/platform/aarch64/rk3588/linker.ld
@@ -5,7 +5,7 @@ SECTIONS
 {
     . = BASE_ADDRESS;
     skernel = .;
-    
+
     .boot : {
         *(.text.boot)
         *(.data.boot)
@@ -50,5 +50,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/aarch64/zcu102/linker.ld
+++ b/platform/aarch64/zcu102/linker.ld
@@ -45,5 +45,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/loongarch64/ls3a5000/linker.ld
+++ b/platform/loongarch64/ls3a5000/linker.ld
@@ -55,5 +55,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/loongarch64/ls3a6000/linker.ld
+++ b/platform/loongarch64/ls3a6000/linker.ld
@@ -55,5 +55,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/riscv64/hifive-premier-p550/linker.ld
+++ b/platform/riscv64/hifive-premier-p550/linker.ld
@@ -46,5 +46,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/riscv64/megrez/linker.ld
+++ b/platform/riscv64/megrez/linker.ld
@@ -46,5 +46,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/riscv64/qemu-aia/linker.ld
+++ b/platform/riscv64/qemu-aia/linker.ld
@@ -46,5 +46,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/riscv64/qemu-plic/linker.ld
+++ b/platform/riscv64/qemu-plic/linker.ld
@@ -46,5 +46,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/x86_64/nuc14mnk/linker.ld
+++ b/platform/x86_64/nuc14mnk/linker.ld
@@ -49,5 +49,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/platform/x86_64/qemu/linker.ld
+++ b/platform/x86_64/qemu/linker.ld
@@ -49,5 +49,7 @@ SECTIONS
         *(.eh_frame)
     }
     . = ALIGN(4K);
-	__core_end = .;
+    __core_end = .;
 }
+
+__hv_end = __core_end + HV_EXTENDED_SIZE;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -13,39 +13,73 @@
 //
 // Authors:
 //
+
+//! This module defines core constants and memory layout for the hypervisor.
+//!
+//! It contains definitions for:
+//! - Memory pool sizes and offsets
+//! - Per-CPU data configuration
+//! - Architecture-specific event codes
+//! - Memory boundary access functions
+//! - External assembly symbols for linker interaction
+
 pub use crate::memory::PAGE_SIZE;
 use crate::{memory::addr::VirtAddr, platform::BOARD_NCPUS};
+use core::arch::global_asm;
 
 /// Size of the hypervisor heap.
-pub const HV_HEAP_SIZE: usize = 1024 * 1024; // 1 MB
-pub const HV_MEM_POOL_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+pub const HV_HEAP_SIZE: usize = 1024 * 1024; // 1 MiB
 
-/// Size of the per-CPU data (stack and other CPU-local data).
-pub const PER_CPU_SIZE: usize = 512 * 1024; // 512KB  //may get bigger when dev
+/// Size of the hypervisor memory pool used for dynamic allocation.
+pub const HV_MEM_POOL_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 
-/// Pointer of the per-CPU data array.
+/// Size of the per-CPU data area, including stack and CPU-local data.
+///
+/// This area is allocated for each CPU core and may increase in size during
+/// development.
+pub const PER_CPU_SIZE: usize = 512 * 1024; // 512 KiB
+
+/// Pointer to the beginning of the per-CPU data array.
+///
+/// This array starts immediately after the core memory area ends.
 pub const PER_CPU_ARRAY_PTR: *mut VirtAddr = __core_end as _;
 
+/// Represents an invalid memory address.
 pub const INVALID_ADDRESS: usize = usize::MAX;
 
+/// Maximum number of supported CPU cores.
+///
+/// This is determined by the board-specific configuration.
 pub const MAX_CPU_NUM: usize = BOARD_NCPUS;
 
+/// Maximum number of memory zones supported.
 pub const MAX_ZONE_NUM: usize = 4;
 
+/// Maximum number of spin-wait iterations before timing out.
 pub const MAX_WAIT_TIMES: usize = 100000000;
 
+/// Returns the address of the hypervisor entry point.
+#[allow(dead_code)]
 pub fn hv_start() -> VirtAddr {
     skernel as _
 }
 
+/// Returns the address marking the end of the core memory area.
+///
+/// This is the boundary between statically linked code/data
+/// and the memory allocated for per-CPU data and memory pool.
 pub fn core_end() -> VirtAddr {
     __core_end as _
 }
 
+/// Returns the address of the memory pool start.
+///
+/// The memory pool follows immediately after all per-CPU data areas.
 pub fn mem_pool_start() -> VirtAddr {
     core_end() + MAX_CPU_NUM * PER_CPU_SIZE
 }
 
+/// Returns the address marking the end of the entire hypervisor memory.
 pub fn hv_end() -> VirtAddr {
     mem_pool_start() + HV_MEM_POOL_SIZE
 }
@@ -56,6 +90,32 @@ pub const IPI_EVENT_UPDATE_HART_LINE: usize = 5;
 pub const IPI_EVENT_SEND_IPI: usize = 6;
 
 extern "C" {
+    /// Entry point of the hypervisor written in assembly.
+    ///
+    /// This is the first function executed when the hypervisor boots.
+    #[allow(dead_code)]
     fn skernel();
+
+    /// Symbol marking the end of the core memory area.
+    ///
+    /// This is defined by the linker script and represents the boundary
+    /// between statically linked code/data and dynamic memory areas.
+    #[allow(dead_code)]
     fn __core_end();
 }
+
+/// Total size of the extended memory area from the core end to the end of
+/// the hypervisor memory.
+///
+/// This is calculated as (MAX_CPU_NUM * PER_CPU_SIZE) + HV_MEM_POOL_SIZE and
+/// represents the total additional memory required beyond the core static area.
+#[allow(dead_code)]
+pub const HV_EXTENDED_SIZE: usize = MAX_CPU_NUM * PER_CPU_SIZE + HV_MEM_POOL_SIZE;
+
+// Expose HV_EXTENDED_SIZE as a global assembly symbol for linker accessibility.
+// This makes it easier for the linker script to directly reference this constant value.
+global_asm!(
+    ".global HV_EXTENDED_SIZE",
+    ".equ HV_EXTENDED_SIZE, {hv_extended_size}",
+    hv_extended_size = const HV_EXTENDED_SIZE
+);


### PR DESCRIPTION
This commit enhances the memory management of hvisor by adding hv_end address calculation and output, providing a clear definition of the hvisor memory layout and reserved memory regions.

Key changes:
- Enhanced documentation with comments on all memory boundary functions
- Introduced `HV_EXTENDED_SIZE` constant representing the total additional memory required beyond the core static area
- Exposed `HV_EXTENDED_SIZE` as a global symbol for linker accessibility
- Added compilation output of (START_ADDR END_ADDR) to clearly indicate the reserved memory region for hvisor

This implementation provides a clear and comprehensive view of the hvisor's memory requirements, making it easier to configure memory reservations for hvisor in different deployment scenarios.

Closes: #223 
