### PR TITLE
Bugfix: Pin cargo-xbuild to v0.6.5 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install --version 0.6.5 --locked cargo-xbuild
       - name: Format Check
         run: make fmt-test
 
@@ -69,7 +68,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install --version 0.6.5 --locked cargo-xbuild
       - name: Set up environment variables
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
@@ -154,7 +152,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install --version 0.6.5 --locked cargo-xbuild
           wget -q https://github.com/sunhaiyong1978/CLFS-for-LoongArch/releases/download/8.0/loongarch64-clfs-8.0-cross-tools-gcc-full.tar.xz
           tar -xf loongarch64-clfs-8.0-cross-tools-gcc-full.tar.xz
           echo "$GITHUB_WORKSPACE/cross-tools/bin" >> $GITHUB_PATH
@@ -218,8 +215,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget expect device-tree-compiler p7zip-full gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install --version 0.6.5 --locked cargo-xbuild
-
       - name: Set up environment variables
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install cargo-xbuild
+          cargo install --version 0.6.5 --locked cargo-xbuild
       - name: Format Check
         run: make fmt-test
 
@@ -69,7 +69,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install cargo-xbuild
+          cargo install --version 0.6.5 --locked cargo-xbuild
       - name: Set up environment variables
         run: |
           echo "ARCH=${{ matrix.arch }}" >> $GITHUB_ENV
@@ -154,7 +154,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y wget
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install cargo-xbuild
+          cargo install --version 0.6.5 --locked cargo-xbuild
           wget -q https://github.com/sunhaiyong1978/CLFS-for-LoongArch/releases/download/8.0/loongarch64-clfs-8.0-cross-tools-gcc-full.tar.xz
           tar -xf loongarch64-clfs-8.0-cross-tools-gcc-full.tar.xz
           echo "$GITHUB_WORKSPACE/cross-tools/bin" >> $GITHUB_PATH
@@ -218,7 +218,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget expect device-tree-compiler p7zip-full gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu
           cargo install --version 0.3.0 --locked cargo-binutils
-          cargo install cargo-xbuild
+          cargo install --version 0.6.5 --locked cargo-xbuild
 
       - name: Set up environment variables
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "8a9f4cc54a2e471ff72f1499461ba381ad4eae9cbd60d29c258545b995e406e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]


### PR DESCRIPTION
The CI pipeline recently started failing because cargo-xbuild v0.6.6 (and its dependencies) requires edition2024, which is not supported by our current nightly Rust toolchain (1.80.0).

This PR locks the version to v0.6.5 to restore CI stability while keeping the existing toolchain environment.

Related Error:
feature edition2024 is required but not stabilized in this version of Cargo