### PR TITLE
enhance: add dcache invalid ops for aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "8a9f4cc54a2e471ff72f1499461ba381ad4eae9cbd60d29c258545b995e406e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/src/arch/aarch64/cache.rs
+++ b/src/arch/aarch64/cache.rs
@@ -11,7 +11,8 @@
 // Syswonder Website:
 //      https://www.syswonder.org
 //
-// Authors:
+// Authors: 
+//  Jingyu Liu <liujingyu24s@ict.ac.cn>
 //
 
 pub unsafe fn invalidate_dcache_range(start: usize, size: usize, line_size: usize) {

--- a/src/arch/aarch64/cache.rs
+++ b/src/arch/aarch64/cache.rs
@@ -13,22 +13,13 @@
 //
 // Authors:
 //
-mod cache;
-pub mod consts;
-pub mod cpu;
-pub mod entry;
-pub mod hypercall;
-pub mod iommu;
-pub mod ipi;
-pub mod ivc;
-pub mod mm;
-pub mod mmu;
-pub mod paging;
-pub mod s2pt;
-pub mod sysreg;
-pub mod time;
-pub mod trap;
-pub mod zone;
 
-pub use s2pt::stage2_mode_detect;
-pub use s2pt::Stage2PageTable;
+pub unsafe fn invalidate_dcache_range(start: usize, size: usize, line_size: usize) {
+    let mut addr = start & !(line_size - 1);
+    let end = start + size;
+    while addr < end {
+        core::arch::asm!("dc ivac, {0}", in(reg) addr, options(nostack, preserves_flags));
+        addr += line_size;
+    }
+    core::arch::asm!("dsb sy", options(nostack, preserves_flags));
+}

--- a/src/arch/aarch64/cache.rs
+++ b/src/arch/aarch64/cache.rs
@@ -11,7 +11,7 @@
 // Syswonder Website:
 //      https://www.syswonder.org
 //
-// Authors: 
+// Authors:
 //  Jingyu Liu <liujingyu24s@ict.ac.cn>
 //
 

--- a/src/arch/aarch64/cpu.rs
+++ b/src/arch/aarch64/cpu.rs
@@ -16,10 +16,10 @@
 use crate::{
     arch::{mm::new_s2_memory_set, sysreg::write_sysreg},
     consts::{MAX_CPU_NUM, PAGE_SIZE, PER_CPU_ARRAY_PTR, PER_CPU_SIZE},
-    cpu_data::this_cpu_data,
+    cpu_data::{this_cpu_data, this_zone},
     memory::{
-        addr::PHYS_VIRT_OFFSET, mm::PARKING_MEMORY_SET, GuestPhysAddr, HostPhysAddr, MemFlags,
-        MemoryRegion, VirtAddr, PARKING_INST_PAGE,
+        addr::phys_to_virt, addr::PHYS_VIRT_OFFSET, mm::PARKING_MEMORY_SET, GuestPhysAddr,
+        HostPhysAddr, MemFlags, MemoryRegion, VirtAddr, PARKING_INST_PAGE,
     },
     platform::BOARD_MPIDR_MAPPINGS,
     zone::find_zone,
@@ -30,6 +30,7 @@ use aarch64_cpu::registers::{
 use core::ptr::addr_of;
 
 use super::{
+    cache::invalidate_dcache_range,
     mm::{get_parange, get_parange_bits, is_s2_pt_level3},
     trap::vmreturn,
 };
@@ -205,6 +206,26 @@ impl ArchCpu {
             this_cpu_data().cpu_on_entry
         );
         unsafe {
+            // invalidate Guest related cache, only for RAM regions
+            // Get cache line size from CTR_EL0[16:19] (min line size, in words of 4 bytes)
+            let ctr_el0: u64;
+            core::arch::asm!("mrs {0}, ctr_el0", out(reg) ctr_el0, options(nostack, preserves_flags));
+            let dcache_line_size = 4 * (1 << ((ctr_el0 >> 16 & 0xF) as usize));
+            this_zone().read().gpm.for_each_region(|region| {
+                // Invalidate all RAM regions of the guest
+                if !region.flags.contains(MemFlags::IO) {
+                    let phys_start = region.mapper.map_fn(region.start);
+                    let hva_start = phys_to_virt(phys_start);
+                    info!("Invalidate Guest related cache, region.start: {:#x}, region.size: {:#x}, phys_start: {:#x}, hva_start: {:#x}", region.start, region.size, phys_start, hva_start);
+                    invalidate_dcache_range(hva_start, region.size, dcache_line_size);
+                }
+            });
+            // Invalidate all instruction cache.
+            core::arch::asm!("ic iallu", options(nostack, preserves_flags));
+            // Invalidate all EL1 stage-1 TLB.
+            core::arch::asm!("tlbi alle1", options(nostack, preserves_flags));
+            core::arch::asm!("dsb sy", options(nostack, preserves_flags));
+            core::arch::asm!("isb", options(nostack, preserves_flags));
             vmreturn(self.guest_reg() as *mut _ as usize);
         }
     }

--- a/src/arch/aarch64/cpu.rs
+++ b/src/arch/aarch64/cpu.rs
@@ -16,10 +16,10 @@
 use crate::{
     arch::{mm::new_s2_memory_set, sysreg::write_sysreg},
     consts::{MAX_CPU_NUM, PAGE_SIZE, PER_CPU_ARRAY_PTR, PER_CPU_SIZE},
-    cpu_data::{this_cpu_data, this_zone},
+    cpu_data::this_cpu_data,
     memory::{
-        addr::phys_to_virt, addr::PHYS_VIRT_OFFSET, mm::PARKING_MEMORY_SET, GuestPhysAddr,
-        HostPhysAddr, MemFlags, MemoryRegion, VirtAddr, PARKING_INST_PAGE,
+        addr::PHYS_VIRT_OFFSET, mm::PARKING_MEMORY_SET, GuestPhysAddr, HostPhysAddr, MemFlags,
+        MemoryRegion, VirtAddr, PARKING_INST_PAGE,
     },
     platform::BOARD_MPIDR_MAPPINGS,
     zone::find_zone,
@@ -30,7 +30,6 @@ use aarch64_cpu::registers::{
 use core::ptr::addr_of;
 
 use super::{
-    cache::invalidate_dcache_range,
     mm::{get_parange, get_parange_bits, is_s2_pt_level3},
     trap::vmreturn,
 };
@@ -206,26 +205,6 @@ impl ArchCpu {
             this_cpu_data().cpu_on_entry
         );
         unsafe {
-            // invalidate Guest related cache, only for RAM regions
-            // Get cache line size from CTR_EL0[16:19] (min line size, in words of 4 bytes)
-            let ctr_el0: u64;
-            core::arch::asm!("mrs {0}, ctr_el0", out(reg) ctr_el0, options(nostack, preserves_flags));
-            let dcache_line_size = 4 * (1 << ((ctr_el0 >> 16 & 0xF) as usize));
-            this_zone().read().gpm.for_each_region(|region| {
-                // Invalidate all RAM regions of the guest
-                if !region.flags.contains(MemFlags::IO) {
-                    let phys_start = region.mapper.map_fn(region.start);
-                    let hva_start = phys_to_virt(phys_start);
-                    info!("Invalidate Guest related cache, region.start: {:#x}, region.size: {:#x}, phys_start: {:#x}, hva_start: {:#x}", region.start, region.size, phys_start, hva_start);
-                    invalidate_dcache_range(hva_start, region.size, dcache_line_size);
-                }
-            });
-            // Invalidate all instruction cache.
-            core::arch::asm!("ic iallu", options(nostack, preserves_flags));
-            // Invalidate all EL1 stage-1 TLB.
-            core::arch::asm!("tlbi alle1", options(nostack, preserves_flags));
-            core::arch::asm!("dsb sy", options(nostack, preserves_flags));
-            core::arch::asm!("isb", options(nostack, preserves_flags));
             vmreturn(self.guest_reg() as *mut _ as usize);
         }
     }

--- a/src/arch/aarch64/zone.rs
+++ b/src/arch/aarch64/zone.rs
@@ -15,11 +15,12 @@
 //
 use core::panic;
 
+use super::cache::invalidate_dcache_range;
 use crate::{
     config::*,
     device::virtio_trampoline::mmio_virtio_handler,
     error::HvResult,
-    memory::{GuestPhysAddr, HostPhysAddr, MemFlags, MemoryRegion},
+    memory::{addr::phys_to_virt, GuestPhysAddr, HostPhysAddr, MemFlags, MemoryRegion},
     zone::Zone,
 };
 
@@ -118,6 +119,33 @@ impl Zone {
     }
 
     pub fn arch_zone_post_configuration(&mut self, _config: &HvZoneConfig) -> HvResult {
+        Ok(())
+    }
+
+    pub fn arch_zone_reset(&mut self, _config: &HvZoneConfig) -> HvResult {
+        // This operation serves as an insurance to ensure that
+        //      there is no relevant d-cache line in the cache;
+        //      since the VA has the inner-shareable attribute,
+        //      the cores within the inner-shareable domain will
+        //      be affected by the broadcast invalidation.
+        unsafe {
+            // Get cache line size from CTR_EL0[16:19] (min line size, in words of 4 bytes)
+            let ctr_el0: u64;
+            core::arch::asm!("mrs {0}, ctr_el0", out(reg) ctr_el0, options(nostack, preserves_flags));
+            let dcache_line_size = (1 << ((ctr_el0 >> 16 & 0xF) as usize)) * 4;
+            self.gpm.for_each_region(|region| {
+                // Invalidate all RAM regions of the guest
+                if !region.flags.contains(MemFlags::IO) { // TODO: need to enrich the types and exercise more precise control
+                    // Calculate the physical start address of the region
+                    let phys_start = region.mapper.map_fn(region.start);
+                    // Map phys_start to hvisor virtual address
+                    let hva_start = phys_to_virt(phys_start);
+                    info!("Invalidate Guest related cache, region.start: {:#x}, region.size: {:#x}, phys_start: {:#x}, hva_start: {:#x}", region.start, region.size, phys_start, hva_start);
+                    // D-cache invalid operation will broadcast to all cores, just do it once. There is no need to do it on each core.
+                    invalidate_dcache_range(hva_start, region.size, dcache_line_size);
+                }
+            });
+        }
         Ok(())
     }
 }

--- a/src/arch/loongarch64/zone.rs
+++ b/src/arch/loongarch64/zone.rs
@@ -690,4 +690,8 @@ impl Zone {
     pub fn arch_zone_post_configuration(&mut self, config: &HvZoneConfig) -> HvResult {
         Ok(())
     }
+
+    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+        Ok(())
+    }
 }

--- a/src/arch/loongarch64/zone.rs
+++ b/src/arch/loongarch64/zone.rs
@@ -691,7 +691,7 @@ impl Zone {
         Ok(())
     }
 
-    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+    pub fn arch_zone_reset(&mut self, _config: &HvZoneConfig) -> HvResult {
         Ok(())
     }
 }

--- a/src/arch/riscv64/zone.rs
+++ b/src/arch/riscv64/zone.rs
@@ -65,7 +65,7 @@ impl Zone {
         Ok(())
     }
 
-    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+    pub fn arch_zone_reset(&mut self, _config: &HvZoneConfig) -> HvResult {
         Ok(())
     }
 }

--- a/src/arch/riscv64/zone.rs
+++ b/src/arch/riscv64/zone.rs
@@ -64,6 +64,10 @@ impl Zone {
     pub fn arch_zone_post_configuration(&mut self, _config: &HvZoneConfig) -> HvResult {
         Ok(())
     }
+
+    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+        Ok(())
+    }
 }
 
 #[repr(C)]

--- a/src/arch/x86_64/zone.rs
+++ b/src/arch/x86_64/zone.rs
@@ -150,7 +150,7 @@ impl Zone {
         Ok(())
     }
 
-    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+    pub fn arch_zone_reset(&mut self, _config: &HvZoneConfig) -> HvResult {
         Ok(())
     }
 }

--- a/src/arch/x86_64/zone.rs
+++ b/src/arch/x86_64/zone.rs
@@ -149,6 +149,10 @@ impl Zone {
 
         Ok(())
     }
+
+    pub fn arch_zone_reset(&mut self, config: &HvZoneConfig) -> HvResult {
+        Ok(())
+    }
 }
 
 /*impl BarRegion {

--- a/src/memory/mm.rs
+++ b/src/memory/mm.rs
@@ -107,6 +107,16 @@ where
         true
     }
 
+    /// Iterate over all memory regions in the MemorySet.
+    pub fn for_each_region<F>(&self, mut f: F)
+    where
+        F: FnMut(&MemoryRegion<PT::VA>),
+    {
+        for region in self.regions.values() {
+            f(region);
+        }
+    }
+
     /// Add a memory region to this set.
     pub fn insert(&mut self, region: MemoryRegion<PT::VA>) -> HvResult {
         info!(

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -357,6 +357,9 @@ pub fn zone_create(config: &HvZoneConfig) -> HvResult<Arc<RwLock<Zone>>> {
 
     zone.arch_zone_post_configuration(config)?;
 
+    // Reset the zone arch-related resources, e.g. invalid data cache
+    zone.arch_zone_reset(config)?;
+
     // Initialize the virtual interrupt controller, it needs zone.cpu_num
     zone.virqc_init(config);
 


### PR DESCRIPTION
A flush operation for dcache and a TBLI operation for EL1 were added, and then Icache was cleaned up to ensure that there was no dirty data in the cache when the guest was first executed.

Related with https://github.com/syswonder/hvisor-tool/pull/79 and https://github.com/syswonder/hvisor/issues/239