### PR TITLE
Fix PCIe BAR mapping bug and add gits-reset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "8a9f4cc54a2e471ff72f1499461ba381ad4eae9cbd60d29c258545b995e406e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/src/device/irqchip/gicv3/gits.rs
+++ b/src/device/irqchip/gicv3/gits.rs
@@ -157,6 +157,14 @@ impl Cmdq {
         r
     }
 
+    fn reset_vm(&mut self, zone_id: usize) {
+        assert!(zone_id < MAX_ZONE_NUM, "Invalid zone id!");
+        self.cbaser_list[zone_id] = 0;
+        self.creadr_list[zone_id] = 0;
+        self.cwriter_list[zone_id] = 0;
+        self.cmdq_page_num[zone_id] = 0;
+    }
+
     fn init_real_cbaser(&self) {
         let reg = host_gits_base() + GITS_CBASER;
         let writer = host_gits_base() + GITS_CWRITER;
@@ -494,4 +502,15 @@ pub fn set_ct_baser(value: usize, zone_id: usize) {
     let binding = get_ct(zone_id);
     let mut ct = binding.write();
     ct.set_baser(value);
+}
+
+pub fn gits_reset(zone_id: usize) {
+    let mut cmdq = CMDQ.get().unwrap().lock();
+    cmdq.reset_vm(zone_id);
+    let dt_binding = get_dt(zone_id);
+    let mut dt = dt_binding.write();
+    dt.set_baser(0);
+    let ct_binding = get_ct(zone_id);
+    let mut ct = ct_binding.write();
+    ct.set_baser(0);
 }

--- a/src/device/irqchip/gicv3/mod.rs
+++ b/src/device/irqchip/gicv3/mod.rs
@@ -38,6 +38,7 @@ use crate::arch::zone::GicConfig;
 use crate::config::root_zone_config;
 use crate::consts::{self, MAX_CPU_NUM};
 
+use crate::device::irqchip::gicv3::gits::gits_reset;
 use crate::event::check_events;
 use crate::hypercall::SGI_IPI_ID;
 use crate::zone::Zone;
@@ -487,6 +488,9 @@ impl Zone {
                 write_volatile((gicd_base + GICD_ICENABLER + idx * 4) as *mut u32, mask);
                 write_volatile((gicd_base + GICD_ICACTIVER + idx * 4) as *mut u32, mask);
             }
+        }
+        if host_gits_size() != 0{
+            gits_reset(self.id);
         }
     }
 }

--- a/src/device/irqchip/gicv3/mod.rs
+++ b/src/device/irqchip/gicv3/mod.rs
@@ -489,7 +489,7 @@ impl Zone {
                 write_volatile((gicd_base + GICD_ICACTIVER + idx * 4) as *mut u32, mask);
             }
         }
-        if host_gits_size() != 0{
+        if host_gits_size() != 0 {
             gits_reset(self.id);
         }
     }

--- a/src/pci/pci_handler.rs
+++ b/src/pci/pci_handler.rs
@@ -293,17 +293,8 @@ fn handle_endpoint_access(
                                     });
                                 }
 
-                                let paddr = if is_root {
-                                    dev.with_bar_ref_mut(slot, |bar| bar.set_value(new_vaddr));
-                                    if bar_type == PciMemType::Mem64High {
-                                        dev.with_bar_ref_mut(slot - 1, |bar| {
-                                            bar.set_value(new_vaddr)
-                                        });
-                                    }
-                                    new_vaddr as HostPhysAddr
-                                } else {
-                                    dev.with_bar_ref(slot, |bar| bar.get_value64()) as HostPhysAddr
-                                };
+                                let paddr =
+                                    dev.with_bar_ref(slot, |bar| bar.get_value64()) as HostPhysAddr;
                                 let bar_size = {
                                     let size = dev.with_bar_ref(slot, |bar| bar.get_size());
                                     if crate::memory::addr::is_aligned(size as usize) {


### PR DESCRIPTION
**PCI BAR GPA-HPA mapping bug** : In the old code, during BAR GPA-to-HPA mapping, the HPA value was incorrectly overwritten with the GPA value. This caused guest accesses to be routed to an unknown address range, making the device unusable.

#261 The reason for this error is that after a restart, Linux resets the ITS WRITER register to 0, but hvisor still keeps the virtual READAR from the previous lifecycle. Since the CMD ring allows WRITER< READR to indicate wrap-around usage, this results in meaningless CMD writes and the loop cannot finish.