### PR TITLE
fix: use SeqCst for wakeup check to prevent store-load reordering

### DIFF
--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -241,8 +241,8 @@ impl VirtioBridgeController {
     #[allow(unused)]
     pub fn need_wakeup(&self) -> bool {
         let base = self.base_address.load(Ordering::Relaxed);
+        fence(Ordering::SeqCst);
         let need_wakeup = unsafe { (&*(base as *const VirtioBridge)).need_wakeup.get() };
-        fence(Ordering::Acquire);
         need_wakeup == 1
     }
 }


### PR DESCRIPTION
> **The contents below are the same as [syswonder/hvisor-tool/pull/80](https://github.com/syswonder/hvisor-tool/pull/80).**

This PR addresses a critical memory synchronization violation in the virtio notification path.

By implementing a correct Dekker's Algorithm using `SeqCst` fences, we eliminate the root cause of "lost wakeups" and remove the confusing `nanosleep` workaround.

**The Ambiguity of `nanosleep`:**
The legacy implementation used `nanosleep(TIMEOUT)`(TIMEOUT is 1ms) to "fix" intermittent queue stalls. This was misleading: it didn't fix the synchronization logic but merely limited the maximum stall duration to 1ms. This obscured the real bug and introduced a mandatory latency floor. With proper memory barriers, the system is now both correct and fast.

**Detailed Dependency Analysis:**
The system relies on the visibility of two specific variables:
- **Guest**: Must ensure `Store [req_rear]` is visible to Host before `Load [need_wakeup]`.
- **Host**: Must ensure `Store [need_wakeup]` is visible to Guest before `Load [req_rear]`.

**Cross-Architecture Memory Reordering Analysis:**
The "Lost Wakeup" occurs specifically due to **Store-Load Reordering**. As shown in the table below, while different architectures have varying degrees of relaxation, **all of them** allow Store-Load reordering. This makes a full memory barrier (`SeqCst`) mandatory for correctness across all supported platforms.

| Architecture | Load-Load | Load-Store | Store-Store | Store-Load (The Root Cause) |
| :-: | :-: | :-: | :-: | :-: |
| **x86-64 (TSO)** | No | No | No | **Allowed** |
| **ARMv8 / v9** | Allowed | Allowed | Allowed | **Allowed** |
| **RISC-V (RVWMO)** | Allowed | Allowed | Allowed | **Allowed** |
| **LoongArch** | Allowed | Allowed | Allowed | **Allowed** |

*Note: "Allowed" means the hardware/CPU may reorder these operations for optimization unless an explicit barrier is used.*

**Race Condition Timeline (Lost Wakeup Scenario):**

| Time | Hypervisor (Producer) | Virtio Daemon (Consumer) | Visible Shared State |
| :-: | :-: | :-: | :-: |
| **T1** | `Store [req_rear] = N` (Stuck in Store Buffer) | | `req_rear = 0` (Old) |
| **T2** | | `Store [need_wakeup] = 1` (Stuck in Store Buffer) | `need_wakeup = 0` (Old) |
| **T3** | `Load r1, [need_wakeup]` -> **Reads 0** | | `need_wakeup = 0` |
| **T4** | | `Load r2, [req_rear]` -> **Reads 0** | `req_rear = 0` |
| **T5** | **Decision**: Host is awake. **Action**: No eventfd kick. | **Decision**: Queue empty. **Action**: Enter `epoll_wait`. | **STALL** |
| **T6** | (Optional) Store Buffer Flushed | (Optional) Store Buffer Flushed | `req_rear=N, need_wakeup=1` |

**Why `SeqCst` Fixes This:**
`Ordering::SeqCst` (Sequential Consistency) acts as a full memory barrier. It forces the CPU to flush the Store Buffer and wait for completion before proceeding to the Load.
- It ensures that **T1** must complete (become visible) before **T3**.
- It ensures that **T2** must complete (become visible) before **T4**.
- Consequently, it is mathematically impossible for both sides to read the "old" state simultaneously. At least one side will see the other's update and prevent the stall.
