### PR TITLE
riscv: initial support riscv iommu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,9 @@ uefi-raw = "=0.9.0"
 
 [features]
 ############# general ##############
-iommu = [] # supported by: aarch64
-pci = [] # supported by: aarch64, loongarch64
+iommu = [] # supported by: aarch64, riscv64
+pci = [] # supported by: aarch64, riscv64,loongarch64
+share_s2pt = ["iommu"]
 print_timestamp = [] # print timestamp when logging
 
 ############# PCIe access mechanism ##############

--- a/platform/riscv64/hifive-premier-p550/board.rs
+++ b/platform/riscv64/hifive-premier-p550/board.rs
@@ -36,6 +36,9 @@ pub const NUM_CONTEXTS_PER_HART: usize = 2; // M-mode、S-mode
 pub const SIFIVE_CCACHE_BASE: usize = 0x2010000; // SiFive composable cache controller
 pub const SIFIVE_CCACHE_SIZE: usize = 0x4000; // 16KB
 
+pub const IOMMU_SYS_BASE: usize = 0x0;
+pub const IOMMU_SYS_SIZE: usize = 0x0;
+
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;
 pub const ROOT_ZONE_ENTRY: u64 = 0x90000000;

--- a/platform/riscv64/megrez/board.rs
+++ b/platform/riscv64/megrez/board.rs
@@ -37,6 +37,9 @@ pub const NUM_CONTEXTS_PER_HART: usize = 2; // M-mode、S-mode
 pub const SIFIVE_CCACHE_BASE: usize = 0x2010000; // SiFive composable cache controller
 pub const SIFIVE_CCACHE_SIZE: usize = 0x4000; // 16KB
 
+pub const IOMMU_SYS_BASE: usize = 0x0;
+pub const IOMMU_SYS_SIZE: usize = 0x0;
+
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;
 pub const ROOT_ZONE_ENTRY: u64 = 0x90000000;

--- a/platform/riscv64/qemu-aia/board.rs
+++ b/platform/riscv64/qemu-aia/board.rs
@@ -37,6 +37,10 @@ pub const IMSIC_S_BASE: usize = 0x2800_0000;
 pub const IMSIC_GUEST_NUM: usize = 1; // hvisor only supports 1 guest now.
 pub const IMSIC_GUEST_INDEX: usize = 1;
 pub const IMSIC_NUM_IDS: usize = 0xFF;
+pub const IOMMU_SYS_BASE: usize = 0x3010000;
+pub const IOMMU_SYS_SIZE: usize = 0x1000;
+
+
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;
 pub const ROOT_ZONE_ENTRY: u64 = 0x90000000;

--- a/platform/riscv64/qemu-plic/README.md
+++ b/platform/riscv64/qemu-plic/README.md
@@ -68,3 +68,10 @@ screen /dev/xxx (Replace xxx with the actual number.)
 ### Notes
 In the current configuration, the virtio-console backend runs inside root Linux, not in QEMU.
 Both the root zone and zone1 are assigned one virtio-pci-blk device(using wired-interupt) each.
+
+### IOMMU (draft)
+
+Please confirm qemu-system-riscv64 version >= 10.0.0, add iommu-sys=on for machine param and iommu_platform=on for devices linked behind iommu. (refer to platform.mk)
+
+Add `iommu` and `share_s2pt` features for hvisor.
+

--- a/platform/riscv64/qemu-plic/board.rs
+++ b/platform/riscv64/qemu-plic/board.rs
@@ -32,6 +32,8 @@ pub const PLIC_BASE: usize = 0xc000000;
 pub const PLIC_SIZE: usize = 0x4000000;
 pub const BOARD_PLIC_INTERRUPTS_NUM: usize = 1023; // except irq 0
 pub const NUM_CONTEXTS_PER_HART: usize = 2; // M-mode、S-mode
+pub const IOMMU_SYS_BASE: usize = 0x3010000;
+pub const IOMMU_SYS_SIZE: usize = 0x1000;
 
 // This device is used for qemu-quit.
 #[allow(unused)]

--- a/platform/riscv64/qemu-plic/cargo/features
+++ b/platform/riscv64/qemu-plic/cargo/features
@@ -3,4 +3,3 @@ plic
 sstc
 pci
 ecam_pcie
-iommu

--- a/platform/riscv64/qemu-plic/cargo/features
+++ b/platform/riscv64/qemu-plic/cargo/features
@@ -3,3 +3,4 @@ plic
 sstc
 pci
 ecam_pcie
+iommu

--- a/platform/riscv64/qemu-plic/cargo/features
+++ b/platform/riscv64/qemu-plic/cargo/features
@@ -3,5 +3,3 @@ plic
 sstc
 pci
 ecam_pcie
-iommu
-share_s2pt

--- a/platform/riscv64/qemu-plic/cargo/features
+++ b/platform/riscv64/qemu-plic/cargo/features
@@ -3,3 +3,5 @@ plic
 sstc
 pci
 ecam_pcie
+iommu
+share_s2pt

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -10,7 +10,7 @@ zone0_dtb    := $(image_dir)/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 
-QEMU_ARGS := -machine virt,aclint=on
+QEMU_ARGS := -machine virt,aclint=on,iommu-sys=on
 QEMU_ARGS += -bios default
 QEMU_ARGS += -cpu rv64
 QEMU_ARGS += -smp 4

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -10,7 +10,7 @@ zone0_dtb    := $(image_dir)/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 
-QEMU_ARGS := -machine virt,aclint=on,iommu-sys=on
+QEMU_ARGS := -machine virt,aclint=on #,iommu-sys=on
 QEMU_ARGS += -bios default
 QEMU_ARGS += -cpu rv64
 QEMU_ARGS += -smp 4

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -10,7 +10,7 @@ zone0_dtb    := $(image_dir)/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 
-QEMU_ARGS := -machine virt,aclint=on #,iommu-sys=on
+QEMU_ARGS := -machine virt,aclint=on # ,iommu-sys=on # -d trace:*iommu*
 QEMU_ARGS += -bios default
 QEMU_ARGS += -cpu rv64
 QEMU_ARGS += -smp 4
@@ -25,11 +25,11 @@ QEMU_ARGS += -device loader,file="$(zone0_dtb)",addr=0x8f000000,force-raw=on
 
 QEMU_ARGS += -drive if=none,file=$(FSIMG1),id=hd0,format=raw
 # QEMU_ARGS += -device virtio-blk-device,drive=hd0,bus=virtio-mmio-bus.7
-QEMU_ARGS += -device virtio-blk-pci,drive=hd0,disable-legacy=on,disable-modern=off,addr=01.0
+QEMU_ARGS += -device virtio-blk-pci,drive=hd0,disable-legacy=on,disable-modern=off,addr=01.0 # ,iommu_platform=on
 QEMU_ARGS += -device virtio-serial-device,bus=virtio-mmio-bus.6 -chardev pty,id=X10007000 -device virtconsole,chardev=X10007000 -S
-QEMU_ARGS += -drive if=none,file=$(FSIMG2),id=hd1,format=raw
+QEMU_ARGS += -drive if=none,file=$(FSIMG2),id=hd1,format=qcow2
 # QEMU_ARGS += -device virtio-blk-device,drive=hd1,bus=virtio-mmio-bus.5
-QEMU_ARGS += -device virtio-blk-pci,drive=hd1,disable-legacy=on,disable-modern=off,addr=02.0
+QEMU_ARGS += -device virtio-blk-pci,drive=hd1,disable-legacy=on,disable-modern=off,addr=02.0 #,iommu_platform=on
 # -------------------------------------------------------------------
 
 # QEMU_ARGS := -machine virt

--- a/platform/riscv64/qemu-plic/platform.mk
+++ b/platform/riscv64/qemu-plic/platform.mk
@@ -27,7 +27,7 @@ QEMU_ARGS += -drive if=none,file=$(FSIMG1),id=hd0,format=raw
 # QEMU_ARGS += -device virtio-blk-device,drive=hd0,bus=virtio-mmio-bus.7
 QEMU_ARGS += -device virtio-blk-pci,drive=hd0,disable-legacy=on,disable-modern=off,addr=01.0 # ,iommu_platform=on
 QEMU_ARGS += -device virtio-serial-device,bus=virtio-mmio-bus.6 -chardev pty,id=X10007000 -device virtconsole,chardev=X10007000 -S
-QEMU_ARGS += -drive if=none,file=$(FSIMG2),id=hd1,format=qcow2
+QEMU_ARGS += -drive if=none,file=$(FSIMG2),id=hd1,format=raw
 # QEMU_ARGS += -device virtio-blk-device,drive=hd1,bus=virtio-mmio-bus.5
 QEMU_ARGS += -device virtio-blk-pci,drive=hd1,disable-legacy=on,disable-modern=off,addr=02.0 #,iommu_platform=on
 # -------------------------------------------------------------------

--- a/platform/riscv64/ur-dp1000/board.rs
+++ b/platform/riscv64/ur-dp1000/board.rs
@@ -46,6 +46,9 @@ pub const PLIC_SIZE: usize = 0x4000000;
 pub const BOARD_PLIC_INTERRUPTS_NUM: usize = 0xa0; // except irq 0, here range is [1, 160]
 pub const NUM_CONTEXTS_PER_HART: usize = 3; // M-mode、S-mode and VS-mode(unused)
 
+pub const IOMMU_SYS_BASE: usize = 0x0;
+pub const IOMMU_SYS_SIZE: usize = 0x0;
+
 // ==================================================
 //              Root Zone Config
 // ==================================================

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -17,9 +17,16 @@
 
 #![allow(unused)]
 
+// TODO:
+// - [ ] Remove iommu from arch to device
+// - [ ] Add a abstract interface for all-architecture IOMMU
+// - [ ] Support MSI remapping
+// - [ ] Complete command queue and fault queue
+// - [ ] Support vIOMMU
+// - [ ] Increase more fault tolerance
+
 use crate::memory::Frame;
 use alloc::vec::Vec;
-use core::sync::atomic::{fence, Ordering};
 use log::{error, info, warn};
 use spin::{Mutex, Once};
 use tock_registers::interfaces::{Readable, Writeable};
@@ -27,16 +34,9 @@ use tock_registers::register_bitfields;
 use tock_registers::register_structs;
 use tock_registers::registers::{ReadOnly, ReadWrite};
 
-#[inline(always)]
-fn io_fence() {
-    unsafe {
-        core::arch::asm!("fence iorw, iorw", options(nostack, preserves_flags));
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u64)]
-pub enum IommuDdtMode {
+enum IommuDdtMode {
     Off = 0,        // No inbound memory translations are allowed by the IOMMU.
     Bare = 1,       // NO translation or protection.
     OneLevel = 2,   // One-level device-directory table.
@@ -132,6 +132,19 @@ register_bitfields![u64,
     DDT_DIR [ // RISCV-IOMMU Spec Chap3.1.1 Non-leaf DDT entry
         V OFFSET(0) NUMBITS(1) [],
         PPN OFFSET(10) NUMBITS(44) []
+    ],
+    IOMMU_XQB [ // RISC-V IOMMU Spec Chap6.6 Command-queue base
+                // RISC-V IOMMU Spec Chap6.9 Fault queue base
+        LOG2SZ_1 OFFSET(0) NUMBITS(5) [],
+        PPN OFFSET(10) NUMBITS(44) []
+    ],
+    IOMMU_FQ_TAG [ // RISC-V IOMMU Spec Chap4.2 Fault/Event-Queue
+        CAUSE OFFSET(0) NUMBITS(12) [],
+        PID OFFSET(12) NUMBITS(20) [],
+        PV OFFSET(32) NUMBITS(1) [],
+        PRIV OFFSET(33) NUMBITS(1) [],
+        TYPE OFFSET(34) NUMBITS(6) [],
+        DID OFFSET(40) NUMBITS(24) []
     ]
 ];
 
@@ -140,6 +153,24 @@ register_bitfields![u32,
         BE OFFSET(0) NUMBITS(1) [],
         WSI OFFSET(1) NUMBITS(1) [],
         GXL OFFSET(2) NUMBITS(1) [],
+    ],
+    IOMMU_CQCSR [ // RISCV-IOMMU Spec Chap6.15 Command-queue CSR
+        CQEN OFFSET(0) NUMBITS(1) [],
+        CIE OFFSET(1) NUMBITS(1) [],
+        CQMF OFFSET(8) NUMBITS(1) [],
+        CMDTO OFFSET(9) NUMBITS(1) [],
+        CMDILL OFFSET(10) NUMBITS(1) [],
+        FENCEWIP OFFSET(11) NUMBITS(1) [],
+        CQON OFFSET(16) NUMBITS(1) [],
+        BUSY OFFSET(17) NUMBITS(1) [],
+    ],
+    IOMMU_FQCSR [ // RISCV-IOMMU Spec Chap6.16 Fault-queue CSR
+        FQEN OFFSET(0) NUMBITS(1) [],
+        FIE OFFSET(1) NUMBITS(1) [],
+        FQMF OFFSET(8) NUMBITS(1) [],
+        FQOF OFFSET(9) NUMBITS(1) [],
+        FQON OFFSET(16) NUMBITS(1) [],
+        BUSY OFFSET(17) NUMBITS(1) [],
     ],
     IOMMU_IPSR [ // RISCV-IOMMU Spec Chap6.18 Interrupt pending status register
         CIP OFFSET(0) NUMBITS(1) [],
@@ -157,17 +188,17 @@ register_structs! {
         (0x008 => fctl: ReadWrite<u32, IOMMU_FCTL::Register>),
         (0x00c => _custom1),
         (0x010 => ddtp: ReadWrite<u64, IOMMU_DDTP::Register>),
-        (0x018 => cqb: ReadWrite<u64>),
+        (0x018 => cqb: ReadWrite<u64, IOMMU_XQB::Register>),
         (0x020 => cqh: ReadWrite<u32>),
         (0x024 => cqt: ReadWrite<u32>),
-        (0x028 => fqb: ReadWrite<u64>),
+        (0x028 => fqb: ReadWrite<u64, IOMMU_XQB::Register>),
         (0x030 => fqh: ReadWrite<u32>),
         (0x034 => fqt: ReadWrite<u32>),
         (0x038 => pqb: ReadWrite<u64>),
         (0x040 => pqh: ReadWrite<u32>),
         (0x044 => pqt: ReadWrite<u32>),
-        (0x048 => cqcsr: ReadWrite<u32>),
-        (0x04c => fqcsr: ReadWrite<u32>),
+        (0x048 => cqcsr: ReadWrite<u32, IOMMU_CQCSR::Register>),
+        (0x04c => fqcsr: ReadWrite<u32, IOMMU_FQCSR::Register>),
         (0x050 => pqcsr: ReadWrite<u32>),
         (0x054 => ipsr: ReadWrite<u32, IOMMU_IPSR::Register>),
         (0x058 => iocntovf: ReadWrite<u32>),
@@ -214,7 +245,22 @@ pub fn iommu_add_device(vm_id: usize, device_id: usize, root_pt: usize) {
         iommu.lock().rv_iommu_add_device(device_id, vm_id, root_pt);
     }
     #[cfg(not(feature = "iommu"))]
-    info!("RISC-V IOMMU: do nothing now");
+    info!("RISC-V: iommu_add_device do nothing now");
+}
+
+/// Remove a device from IOMMU
+pub fn iommu_remove_device(vm_id: usize, device_id: usize) {
+    #[cfg(feature = "iommu")]
+    {
+        info!(
+            "RV IOMMU: Remove device, vm_id {}, device_id {}",
+            vm_id, device_id
+        );
+        let iommu = get_iommu();
+        iommu.lock().rv_iommu_remove_device(device_id);
+    }
+    #[cfg(not(feature = "iommu"))]
+    info!("RISC-V: iommu_remove_device do nothing now");
 }
 
 /// Initialize RISC-V IOMMU with hardware DDTP probing.
@@ -229,6 +275,36 @@ fn riscv_iommu_init() {
 }
 
 impl IommuHw {
+    const CQ_ENTRY_SIZE: usize = 16;
+    const FQ_ENTRY_SIZE: usize = 32;
+    const CQ_LOG2SZ_1: u32 = 7; // k-1, where k=log2(N), N=256
+    const FQ_LOG2SZ_1: u32 = 6; // k-1, where k=log2(N), N=128
+    const CQ_ENTRIES: usize = 1usize << (Self::CQ_LOG2SZ_1 + 1);
+    const FQ_ENTRIES: usize = 1usize << (Self::FQ_LOG2SZ_1 + 1);
+    const QUEUE_ON_TIMEOUT: usize = 1_000_000;
+
+    fn wait_cq_on(&self) {
+        let mut loops = 0usize;
+        while !self.cqcsr.is_set(IOMMU_CQCSR::CQON) {
+            core::hint::spin_loop();
+            loops += 1;
+            if loops >= Self::QUEUE_ON_TIMEOUT {
+                panic!("RISC-V IOMMU: timeout waiting for CQON");
+            }
+        }
+    }
+
+    fn wait_fq_on(&self) {
+        let mut loops = 0usize;
+        while !self.fqcsr.is_set(IOMMU_FQCSR::FQON) {
+            core::hint::spin_loop();
+            loops += 1;
+            if loops >= Self::QUEUE_ON_TIMEOUT {
+                panic!("RISC-V IOMMU: timeout waiting for FQON");
+            }
+        }
+    }
+
     fn try_set_ddtp(&mut self, ddt_addr: usize, mode: IommuDdtMode) -> bool {
         while self.ddtp.is_set(IOMMU_DDTP::BUSY) {}
         self.ddtp.write(
@@ -290,7 +366,13 @@ impl IommuHw {
         }
     }
 
-    fn rv_iommu_init(&mut self, ddt_addr: usize, ddt_mode: IommuDdtMode) -> IommuDdtMode {
+    fn rv_iommu_init(
+        &mut self,
+        ddt_addr: usize,
+        ddt_mode: IommuDdtMode,
+        cq_addr: usize,
+        fq_addr: usize,
+    ) -> IommuDdtMode {
         // RISC-V IOMMU Spec Chap7.2 Guidelines for initialization
         // Read the capabilities register to discover the capabilities of the IOMMU.
         self.rv_iommu_check_features();
@@ -304,16 +386,33 @@ impl IommuHw {
                 + IOMMU_IPSR::PMIP::SET
                 + IOMMU_IPSR::PIP::SET,
         );
-        // TODO: support MSI
-        // TODO: program the command queue
-        self.cqb.set(0x0);
-        self.cqh.set(0x0);
+        // TODO: support MSI-translation
+
+        // TODO: program icvec
+
+        // Program command queue:
+        // Here use static one frame for command queue.
+        let cq_size = Self::CQ_ENTRIES * Self::CQ_ENTRY_SIZE;
+        self.cqb.write(
+            IOMMU_XQB::LOG2SZ_1.val(Self::CQ_LOG2SZ_1 as u64)
+                + IOMMU_XQB::PPN.val((cq_addr as u64) >> 12),
+        );
         self.cqt.set(0x0);
-        // TODO: program the fault queue
-        self.fqb.set(0x0);
+        self.cqcsr.write(IOMMU_CQCSR::CQEN::SET);
+        self.wait_cq_on();  // Poll cqcsr.cqon until it reads 1
+
+        // Program fault queue:
+        // Here use static one frame for fault queue.
+        let fq_size = Self::FQ_ENTRIES * Self::FQ_ENTRY_SIZE;
+        self.fqb.write(
+            IOMMU_XQB::LOG2SZ_1.val(Self::FQ_LOG2SZ_1 as u64)
+                + IOMMU_XQB::PPN.val((fq_addr as u64) >> 12),
+        );
         self.fqh.set(0x0);
-        self.fqt.set(0x0);
-        // TODO: program the page-request queue
+        self.fqcsr.write(IOMMU_FQCSR::FQEN::SET);
+        self.wait_fq_on();  // Poll fqcsr.fqon until it reads 1
+
+        // Do not support page-request queue.
         self.pqb.set(0x0);
         self.pqh.set(0x0);
         self.pqt.set(0x0);
@@ -349,7 +448,7 @@ struct DdtLeafTable {
 }
 
 /// Device-directory table
-pub struct DdtRootMemory {
+struct DdtRootMemory {
     mode: IommuDdtMode,
     root: Frame,
     lower_levels: Vec<Frame>,
@@ -431,9 +530,27 @@ impl DdtRootMemory {
     }
 }
 
-pub struct Iommu {
-    pub base: usize,
-    ddt: DdtRootMemory,
+/// Command queue entry, RISC-V IOMMU Spec v1.0 Chap4.1 Command-queue
+#[repr(C)]
+struct CqEntry {
+    cmd: ReadWrite<u128>,   // TODO: split into detailed fields
+}
+
+/// Fault queue entry, RISC-V IOMMU Spec v1.0 Chap4.2 Fault/Event-Queue
+#[repr(C)]
+struct FqEntry {
+    tags: ReadWrite<u64, IOMMU_FQ_TAG::Register>,
+    __rsv: ReadWrite<u64>,
+    iotval: ReadWrite<u64>,
+    iotval2: ReadWrite<u64>,
+}
+
+/// Global IOMMU structure
+struct Iommu {
+    base: usize,
+    ddt: DdtRootMemory, // device-directory table
+    cq: Frame, // command queue
+    fq: Frame, // fault queue
 }
 
 impl Iommu {
@@ -441,6 +558,8 @@ impl Iommu {
         Self {
             base,
             ddt: DdtRootMemory::new(),
+            cq: Frame::new_zero().unwrap(),
+            fq: Frame::new_zero().unwrap(),
         }
     }
 
@@ -459,9 +578,12 @@ impl Iommu {
     fn rv_iommu_init(&mut self) {
         // Always probe from the highest practical mode, then fallback by retention.
         let requested_mode = IommuDdtMode::ThreeLevel;
-        let selected_mode = self
-            .iommu()
-            .rv_iommu_init(self.ddt_root_paddr(), requested_mode);
+        let selected_mode = self.iommu().rv_iommu_init(
+            self.ddt_root_paddr(),
+            requested_mode,
+            self.cq.start_paddr(),
+            self.fq.start_paddr(),
+        );
         if selected_mode != requested_mode {
             warn!(
                 "RV IOMMU: DDTP mode downgraded from {:?} to {:?}",

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -13,16 +13,220 @@
 //
 // Authors:
 //      ForeverYolo <2572131118@qq.com>
+//      Jingyu Liu <liujingyu24s@ict.ac.cn>
 
-#[allow(unused)]
-pub fn iommu_init() {
-    info!("riscv: iommu_init: do nothing now");
+#![allow(unused)]
+
+use crate::memory::Frame;
+use log::{error, info};
+use spin::{Once, RwLock};
+
+const IOMMU_MODE: usize = 0x2;
+pub const BLK_PCI_ID: usize = 0x4;
+pub const PCIE_MMIO_BEG: usize = 0x4000_0000;
+pub const PCIE_MMIO_SIZE: usize = 0x0000_0000;
+pub const PCI_MAP_BEG: usize = 0x4_0000_0000;
+pub const PCI_MAP_SIZE: usize = 0x4_0000_0000;
+
+// # Memory-mapped Register Interface
+//  Capabilities register fields
+const RV_IOMMU_CAPS_VERSION_MASK: usize = 0xff;
+const RV_IOMMU_CAPS_IGS_MASK: usize = 0x3 << 28;
+const RV_IOMMU_SUPPORTED_VERSION: usize = 0x10;
+const RV_IOMMU_CAPS_SV39X4_BIT: usize = 0x1 << 17;
+const RV_IOMMU_CAPS_MSI_FLAT_BIT: usize = 0x1 << 17;
+const RV_IOMMU_CAPS_AMO_HWAD_BIT: usize = 0x1 << 24;
+
+// Features control register fields
+const RV_IOMMU_FCTL_DEFAULT: u32 = 0x1 << 1;
+
+// Interrupt pending register
+// const RV_IOMMU_IPSR_FIP_BIT: u32 = 1 << 1;
+const RV_IOMMU_IPSR_CLEAR: u32 = 0x0F;
+
+// Interrupt Vectors
+// const RV_IOMMU_ICVEC_DEFAULT: usize = 0x1 << 4;
+
+// Confiure DC
+const RV_IOMMU_DC_VALID_BIT: usize = 1 << 0;
+const RV_IOMMU_IOHGATP_SV39X4: usize = 8 << 60;
+const RV_IOMMU_DC_IOHGATP_PPN_MASK: usize = 0xFFF_FFFF_FFFF;
+const RV_IOMMU_DC_IOHGATP_GSCID_MASK: usize = 0xFFFF << 44;
+const RV_IOMMU_DDTP_PPN_MASK: usize = 0xFFF_FFFF_FFFF << 10;
+
+pub static IOMMU: Once<RwLock<Iommu>> = Once::new();
+
+pub fn iommu<'a>() -> &'a RwLock<Iommu> {
+    IOMMU.get().expect("Uninitialized hypervisor iommu!")
 }
 
-#[allow(unused)]
-pub fn iommu_add_device(vmid: usize, sid: usize) {
+// alloc the Fram for DDT
+pub fn iommu_init() {
+    let iommu = Iommu::new(crate::platform::IOMMU_SYS_BASE);
+    IOMMU.call_once(|| RwLock::new(iommu));
+    rv_iommu_init();
+}
+
+// master CPU do!
+pub fn rv_iommu_init() {
+    let iommu = iommu();
+    let _ = iommu.write().rv_iommu_init();
+}
+
+// every DMA device do!
+pub fn iommu_add_device(vm_id: usize, device_id: usize, root_pt: usize) {
     info!(
-        "riscv: iommu_add_device: do nothing now, vmid: {}, sid: {}",
-        vmid, sid
+        "RV_IOMMU_ADD_DEVICE: root_pt {:#x}, vm_id {}",
+        root_pt, vm_id
     );
+    let iommu = iommu();
+    iommu.write().rv_iommu_add_device(device_id, vm_id, root_pt);
+}
+
+#[repr(C)]
+#[repr(align(0x1000))]
+pub struct IommuHw {
+    caps: u64,
+    fctl: u32,
+    __custom1: [u8; 4],
+    ddtp: u64,
+    cqb: u64,
+    cqh: u32,
+    cqt: u32,
+    fqb: u64,
+    fqh: u32,
+    fqt: u32,
+    pqb: u64,
+    pqh: u32,
+    pqt: u32,
+    cqcsr: u32,
+    fqcsr: u32,
+    pqcsr: u32,
+    ipsr: u32,
+    iocntovf: u32,
+    iocntinh: u32,
+    iohpmcycles: u64,
+    iohpmctr: [u64; 31],
+    iohpmevt: [u64; 31],
+    tr_req_iova: u64,
+    tr_req_ctl: u64,
+    tr_response: u64,
+    __rsv1: [u8; 64],
+    __custom2: [u8; 72],
+    icvec: u64,
+    msi_cfg_tbl: [MsiCfgTbl; 16],
+    __rsv2: [u8; 3072],
+}
+
+// #define BIT64_MASK(OFF, LEN) ((((UINT64_C(1) << ((LEN)-1)) << 1) - 1) << (OFF))
+
+impl IommuHw {
+    pub fn rv_iommu_check_features(&self) {
+        let caps = self.caps as usize;
+        let version = caps & RV_IOMMU_CAPS_VERSION_MASK;
+        if version != RV_IOMMU_SUPPORTED_VERSION {
+            panic!(
+                "RISC-V IOMMU unsupported version: {}, Please check the IOMMU version",
+                version
+            );
+        }
+        if caps & RV_IOMMU_CAPS_SV39X4_BIT == 0 {
+            warn!("RISC-V IOMMU HW does not support Sv39x4");
+        }
+        if caps & RV_IOMMU_CAPS_MSI_FLAT_BIT == 0 {
+            warn!(
+                "RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)"
+            );
+        }
+        if caps & RV_IOMMU_CAPS_IGS_MASK == 0 {
+            warn!("RISC-V IOMMU HW does not support WSI generation");
+        }
+        if caps & RV_IOMMU_CAPS_AMO_HWAD_BIT == 0 {
+            warn!("RISC-V IOMMU HW AMO HWAD unsupport");
+        }
+    }
+
+    pub fn rv_iommu_init(&mut self, ddt_addr: usize) {
+        // Read and check caps
+        self.rv_iommu_check_features();
+        // Set fctl.WSI We will be first using WSI as IOMMU interrupt mechanism
+        self.fctl = RV_IOMMU_FCTL_DEFAULT;
+        // Clear all IP flags (ipsr)
+        self.ipsr = RV_IOMMU_IPSR_CLEAR;
+        // Configure ddtp with DDT base address and IOMMU mode
+        self.ddtp = IOMMU_MODE as u64 | ((ddt_addr >> 2) & RV_IOMMU_DDTP_PPN_MASK) as u64;
+        // self.ddtp = PLATFORM.iommu_mode as u64 | ddt_addr as u64;
+        // error!{"RV_IOMMU_INIT: DDTP mode {:#x}, DDT_ADDR {:#x}", PLATFORM.iommu_mode, ddt_addr};
+    }
+}
+
+#[repr(C)]
+struct MsiCfgTbl {
+    addr: u64,
+    data: u32,
+    vctl: u32,
+}
+
+#[repr(C)]
+struct DdtEntry {
+    tc: u64,
+    iohgatp: u64,
+    ta: u64,
+    fsc: u64,
+    msiptp: u64,
+    msi_addr_mask: u64,
+    msi_addr_pattern: u64,
+    __rsv: u64,
+}
+
+#[repr(C)]
+pub struct Lvl1DdtHw {
+    dc: [DdtEntry; 64],
+}
+
+pub struct Iommu {
+    pub base: usize,
+    pub ddt: Frame,
+}
+
+impl Iommu {
+    pub fn new(base: usize) -> Self {
+        Self {
+            base: base,
+            ddt: Frame::new_zero().unwrap(),
+        }
+    }
+
+    pub fn iommu(&self) -> &mut IommuHw {
+        unsafe { &mut *(self.base as *mut _) }
+    }
+
+    pub fn dc(&self) -> &mut Lvl1DdtHw {
+        unsafe { &mut *(self.ddt.start_paddr() as *mut _) }
+    }
+
+    pub fn rv_iommu_init(&mut self) {
+        self.iommu().rv_iommu_init(self.ddt.start_paddr());
+    }
+
+    pub fn rv_iommu_add_device(&self, device_id: usize, vm_id: usize, root_pt: usize) {
+        if device_id > 0 && device_id < 64 {
+            // configure DC
+            let tc: u64 = 0 | RV_IOMMU_DC_VALID_BIT as u64 | 1 << 4;
+            self.dc().dc[device_id].tc = tc;
+            let mut iohgatp: u64 = 0;
+            iohgatp |= (root_pt as u64 >> 12) & RV_IOMMU_DC_IOHGATP_PPN_MASK as u64;
+            iohgatp |= (vm_id as u64) & RV_IOMMU_DC_IOHGATP_GSCID_MASK as u64;
+            iohgatp |= RV_IOMMU_IOHGATP_SV39X4 as u64;
+            self.dc().dc[device_id].iohgatp = iohgatp;
+            self.dc().dc[device_id].fsc = 0;
+            info!("{:#x}", &mut self.dc().dc[device_id] as *mut _ as usize);
+            info!(
+                "RV IOMMU: Write DDT, add decive context, iohgatp {:#x}",
+                iohgatp
+            );
+        } else {
+            info!("RV IOMMU: Invalid device ID: {}", device_id);
+        }
+    }
 }

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -193,7 +193,10 @@ pub fn iommu_add_device(vm_id: usize, device_id: usize, root_pt: usize) {
 
 /// Initialize RISC-V IOMMU with hardware DDTP probing.
 fn riscv_iommu_init() {
-    assert!(crate::platform::IOMMU_SYS_SIZE == 0x1000, "IOMMU_SYS_SIZE is not 0x1000");
+    assert!(
+        crate::platform::IOMMU_SYS_SIZE == 0x1000,
+        "IOMMU_SYS_SIZE is not 0x1000"
+    );
     let iommu = Iommu::new(crate::platform::IOMMU_SYS_BASE);
     IOMMU.call_once(|| RwLock::new(iommu));
     get_iommu().write().rv_iommu_init();
@@ -247,7 +250,9 @@ impl IommuHw {
         }
         if !self.caps.is_set(IOMMU_CAPS::MSI_FLAT) {
             // Current DDT Entry only supports Extented-for
-            todo!("RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)");
+            todo!(
+                "RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)"
+            );
         }
         if self.caps.read(IOMMU_CAPS::IGS) == IOMMU_CAPS::IGS::MSI.value {
             warn!("RISC-V IOMMU HW does not support WSI generation");
@@ -451,12 +456,14 @@ impl Iommu {
             3 => DDT_IOHGATP::MODE::SV39X4,
             4 => DDT_IOHGATP::MODE::SV48X4,
             5 => DDT_IOHGATP::MODE::SV57X4,
-            _ => panic!("Invalid stage-2 pt level: {}", unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL }),
+            _ => panic!("Invalid stage-2 pt level: {}", unsafe {
+                crate::arch::s2pt::GSTAGE_PT_LEVEL
+            }),
         };
         entry.iohgatp.write(
             DDT_IOHGATP::PPN.val((root_pt as u64) >> 12)
                 + DDT_IOHGATP::GSCID.val(vm_id as u64)
-                + iohgatp_mode
+                + iohgatp_mode,
         );
         // Bare first-stage context.
         entry.fsc.write(DDT_FSC::MODE::BARE);

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -399,7 +399,7 @@ impl IommuHw {
         );
         self.cqt.set(0x0);
         self.cqcsr.write(IOMMU_CQCSR::CQEN::SET);
-        self.wait_cq_on();  // Poll cqcsr.cqon until it reads 1
+        self.wait_cq_on(); // Poll cqcsr.cqon until it reads 1
 
         // Program fault queue:
         // Here use static one frame for fault queue.
@@ -410,7 +410,7 @@ impl IommuHw {
         );
         self.fqh.set(0x0);
         self.fqcsr.write(IOMMU_FQCSR::FQEN::SET);
-        self.wait_fq_on();  // Poll fqcsr.fqon until it reads 1
+        self.wait_fq_on(); // Poll fqcsr.fqon until it reads 1
 
         // Do not support page-request queue.
         self.pqb.set(0x0);
@@ -533,7 +533,7 @@ impl DdtRootMemory {
 /// Command queue entry, RISC-V IOMMU Spec v1.0 Chap4.1 Command-queue
 #[repr(C)]
 struct CqEntry {
-    cmd: ReadWrite<u128>,   // TODO: split into detailed fields
+    cmd: ReadWrite<u128>, // TODO: split into detailed fields
 }
 
 /// Fault queue entry, RISC-V IOMMU Spec v1.0 Chap4.2 Fault/Event-Queue
@@ -549,8 +549,8 @@ struct FqEntry {
 struct Iommu {
     base: usize,
     ddt: DdtRootMemory, // device-directory table
-    cq: Frame, // command queue
-    fq: Frame, // fault queue
+    cq: Frame,          // command queue
+    fq: Frame,          // fault queue
 }
 
 impl Iommu {

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -21,7 +21,7 @@ use crate::memory::Frame;
 use alloc::vec::Vec;
 use core::sync::atomic::{fence, Ordering};
 use log::{error, info, warn};
-use spin::{Once, RwLock};
+use spin::{Mutex, Once};
 use tock_registers::interfaces::{Readable, Writeable};
 use tock_registers::register_bitfields;
 use tock_registers::register_structs;
@@ -37,16 +37,15 @@ fn io_fence() {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u64)]
 pub enum IommuDdtMode {
-    Off = 0,
-    Bare = 1,
-    OneLevel = 2,
-    TwoLevel = 3,
-    ThreeLevel = 4,
+    Off = 0,        // No inbound memory translations are allowed by the IOMMU.
+    Bare = 1,       // NO translation or protection.
+    OneLevel = 2,   // One-level device-directory table.
+    TwoLevel = 3,   // Two-level device-directory table.
+    ThreeLevel = 4, // Three-level device-directory table.
 }
 
-// RISC-V IOMMU Spec Chap6.3 IOMMU capabilities
 register_bitfields![u64,
-    IOMMU_CAPS [
+    IOMMU_CAPS [    // RISC-V IOMMU Spec Chap6.3 IOMMU capabilities
         VERSION OFFSET(0) NUMBITS(8) [
             VERSION_1_0 = 0x10,
         ],
@@ -78,11 +77,11 @@ register_bitfields![u64,
         PD8 OFFSET(38) NUMBITS(1) [],
         PD17 OFFSET(39) NUMBITS(1) [],
         PD20 OFFSET(40) NUMBITS(1) [],
-        QOS OFFSET(41) NUMBITS(1) [],
+        QOSID OFFSET(41) NUMBITS(1) [],
         NL OFFSET(42) NUMBITS(1) [],
         S OFFSET(43) NUMBITS(1) [],
     ],
-    IOMMU_DDTP [
+    IOMMU_DDTP [ // RISCV-IOMMU Spec Chap6.5 Device-directory table pointer
         MODE OFFSET(0) NUMBITS(4) [
             OFF = 0,
             BARE = 1,
@@ -93,11 +92,21 @@ register_bitfields![u64,
         BUSY OFFSET(4) NUMBITS(1) [],
         PPN OFFSET(10) NUMBITS(44) []
     ],
-    DDT_TC [
+    DDT_TC [ // RISCV-IOMMU Spec Chap3.1.3.1 Translation Control
         V OFFSET(0) NUMBITS(1) [],
-        EN_PRI OFFSET(4) NUMBITS(1) []
+        EN_ATS OFFSET(1) NUMBITS(1) [],
+        EN_PRI OFFSET(2) NUMBITS(1) [],
+        T2GPA OFFSET(3) NUMBITS(1) [],
+        DT2GPA OFFSET(4) NUMBITS(1) [],
+        PDTV OFFSET(5) NUMBITS(1) [],
+        PRP OFFSET(6) NUMBITS(1) [],
+        GADEV OFFSET(7) NUMBITS(1) [],
+        SADEV OFFSET(8) NUMBITS(1) [],
+        DPE OFFSET(9) NUMBITS(1) [],
+        SBE OFFSET(10) NUMBITS(1) [],
+        SXL OFFSET(11) NUMBITS(1) []
     ],
-    DDT_IOHGATP [
+    DDT_IOHGATP [ // RISCV-IOMMU Spec Chap3.1.3.2 IO hypervisor guest address translation and protection
         PPN OFFSET(0) NUMBITS(44) [],
         GSCID OFFSET(44) NUMBITS(16) [],
         MODE OFFSET(60) NUMBITS(4) [
@@ -106,24 +115,33 @@ register_bitfields![u64,
             SV57X4 = 10
         ]
     ],
-    DDT_FSC [
-        MODE OFFSET(0) NUMBITS(4) [
-            BARE = 0
-        ]
+    DDT_TA [ // RISCV-IOMMU Spec Chap3.1.3.3 Translation attributes
+        PS_CID OFFSET(12) NUMBITS(20) [],
+        RCID OFFSET(40) NUMBITS(12) [],
+        MTYPE OFFSET(52) NUMBITS(12) [],
     ],
-    DDT_DIR [
+    DDT_FSC [ // RISCV-IOMMU Spec Chap3.1.3.4 First-stage context
+        MODE OFFSET(60) NUMBITS(4) [
+            BARE = 0,
+            SV39 = 8,
+            SV48 = 9,
+            SV57 = 10
+        ],
+        PPN OFFSET(0) NUMBITS(44) []
+    ],
+    DDT_DIR [ // RISCV-IOMMU Spec Chap3.1.1 Non-leaf DDT entry
         V OFFSET(0) NUMBITS(1) [],
         PPN OFFSET(10) NUMBITS(44) []
     ]
 ];
 
 register_bitfields![u32,
-    IOMMU_FCTL [
+    IOMMU_FCTL [ // RISCV-IOMMU Spec Chap6.4 Features-control register
         BE OFFSET(0) NUMBITS(1) [],
         WSI OFFSET(1) NUMBITS(1) [],
         GXL OFFSET(2) NUMBITS(1) [],
     ],
-    IOMMU_IPSR [
+    IOMMU_IPSR [ // RISCV-IOMMU Spec Chap6.18 Interrupt pending status register
         CIP OFFSET(0) NUMBITS(1) [],
         FIP OFFSET(1) NUMBITS(1) [],
         PMIP OFFSET(2) NUMBITS(1) [],
@@ -170,25 +188,33 @@ register_structs! {
 }
 
 /// Global IOMMU instance
-static IOMMU: Once<RwLock<Iommu>> = Once::new();
+static IOMMU: Once<Mutex<Iommu>> = Once::new();
 
-fn get_iommu<'a>() -> &'a RwLock<Iommu> {
+fn get_iommu<'a>() -> &'a Mutex<Iommu> {
     IOMMU.get().expect("Uninitialized hypervisor iommu!")
 }
 
 /// Initialize IOMMU with default mode
 pub fn iommu_init() {
+    #[cfg(feature = "iommu")]
     riscv_iommu_init();
+    #[cfg(not(feature = "iommu"))]
+    info!("RISC-V IOMMU: do nothing now");
 }
 
 /// Add a device to IOMMU
 pub fn iommu_add_device(vm_id: usize, device_id: usize, root_pt: usize) {
-    info!(
-        "RV_IOMMU_ADD_DEVICE: root_pt {:#x}, vm_id {}",
-        root_pt, vm_id
-    );
-    let iommu = get_iommu();
-    iommu.write().rv_iommu_add_device(device_id, vm_id, root_pt);
+    #[cfg(feature = "iommu")]
+    {
+        info!(
+            "RV IOMMU: Add device, root_pt {:#x}, vm_id {}, device_id {}",
+            root_pt, vm_id, device_id
+        );
+        let iommu = get_iommu();
+        iommu.lock().rv_iommu_add_device(device_id, vm_id, root_pt);
+    }
+    #[cfg(not(feature = "iommu"))]
+    info!("RISC-V IOMMU: do nothing now");
 }
 
 /// Initialize RISC-V IOMMU with hardware DDTP probing.
@@ -198,8 +224,8 @@ fn riscv_iommu_init() {
         "IOMMU_SYS_SIZE is not 0x1000"
     );
     let iommu = Iommu::new(crate::platform::IOMMU_SYS_BASE);
-    IOMMU.call_once(|| RwLock::new(iommu));
-    get_iommu().write().rv_iommu_init();
+    IOMMU.call_once(|| Mutex::new(iommu));
+    get_iommu().lock().rv_iommu_init();
 }
 
 impl IommuHw {
@@ -214,11 +240,17 @@ impl IommuHw {
     }
 
     fn set_ddtp(&mut self, ddt_addr: usize, requested_mode: IommuDdtMode) -> IommuDdtMode {
-        let candidates: &[IommuDdtMode] = &[
-            IommuDdtMode::ThreeLevel,
-            IommuDdtMode::TwoLevel,
-            IommuDdtMode::OneLevel,
-        ];
+        let candidates: &[IommuDdtMode] = match requested_mode {
+            IommuDdtMode::Off => &[],
+            IommuDdtMode::Bare => &[IommuDdtMode::Bare],
+            IommuDdtMode::OneLevel => &[IommuDdtMode::OneLevel],
+            IommuDdtMode::TwoLevel => &[IommuDdtMode::TwoLevel, IommuDdtMode::OneLevel],
+            IommuDdtMode::ThreeLevel => &[
+                IommuDdtMode::ThreeLevel,
+                IommuDdtMode::TwoLevel,
+                IommuDdtMode::OneLevel,
+            ],
+        };
         for mode in candidates {
             if self.try_set_ddtp(ddt_addr, *mode) {
                 info!("RISC-V IOMMU: DDTP mode set to {:?}", *mode);
@@ -239,20 +271,19 @@ impl IommuHw {
         }
         // Note: here RISCV-IOMMU and CPU share the same stage-2 page table.
         let cpu_s2pt_lvl = unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL };
-        if !self.caps.is_set(IOMMU_CAPS::SV39X4) && cpu_s2pt_lvl == 3 {
+        if cpu_s2pt_lvl == 3 && !self.caps.is_set(IOMMU_CAPS::SV39X4) {
             panic!("CPU s2pt is Sv39x4, but IOMMU does not support Sv39x4");
         }
-        if !self.caps.is_set(IOMMU_CAPS::SV48X4) && cpu_s2pt_lvl == 4 {
+        if cpu_s2pt_lvl == 4 && !self.caps.is_set(IOMMU_CAPS::SV48X4) {
             panic!("CPU s2pt is Sv48x4, but IOMMU does not support Sv48x4");
         }
-        if !self.caps.is_set(IOMMU_CAPS::SV57X4) && cpu_s2pt_lvl == 5 {
+        if cpu_s2pt_lvl == 5 && !self.caps.is_set(IOMMU_CAPS::SV57X4) {
             panic!("CPU s2pt is Sv57x4, but IOMMU does not support Sv57x4");
         }
+        // If capabilities.MSI_FLAT is 1 then the Extended Format is used else the Base Format is used.
         if !self.caps.is_set(IOMMU_CAPS::MSI_FLAT) {
             // Current DDT Entry only supports Extented-for
-            todo!(
-                "RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)"
-            );
+            todo!("To support Base-format DDT Entry");
         }
         if self.caps.read(IOMMU_CAPS::IGS) == IOMMU_CAPS::IGS::MSI.value {
             warn!("RISC-V IOMMU HW does not support WSI generation");
@@ -275,8 +306,17 @@ impl IommuHw {
         );
         // TODO: support MSI
         // TODO: program the command queue
+        self.cqb.set(0x0);
+        self.cqh.set(0x0);
+        self.cqt.set(0x0);
         // TODO: program the fault queue
+        self.fqb.set(0x0);
+        self.fqh.set(0x0);
+        self.fqt.set(0x0);
         // TODO: program the page-request queue
+        self.pqb.set(0x0);
+        self.pqh.set(0x0);
+        self.pqt.set(0x0);
 
         // Configure ddtp with DDT base address and IOMMU mode
         self.set_ddtp(ddt_addr, ddt_mode)
@@ -296,7 +336,7 @@ struct DdtEntry {
     __rsv: ReadWrite<u64>,
 }
 
-/// Intermediate device-directory table
+/// Non-leaf device-directory table
 #[repr(C)]
 struct DdtDirTable {
     entries: [ReadWrite<u64, DDT_DIR::Register>; 512],
@@ -432,6 +472,19 @@ impl Iommu {
     }
 
     fn rv_iommu_add_device(&mut self, device_id: usize, vm_id: usize, root_pt: usize) {
+        if device_id == 0 {
+            info!("Skip Device with device_id = 0");
+            return;
+        }
+        // Check riscv stage-2 pt, root pt should be 16KiB aligned.
+        if root_pt & ((16 * 1024) - 1) != 0 {
+            error!(
+                "RV IOMMU: iohgatp root page-table is not 16KiB aligned: {:#x}",
+                root_pt
+            );
+            return;
+        }
+
         let Some(entry) = self.ddt.get_or_alloc_leaf_entry(device_id) else {
             warn!(
                 "RV IOMMU: Invalid device ID {} for DDT mode {:?}",
@@ -442,31 +495,28 @@ impl Iommu {
         };
 
         // Prepare TC without publishing VALID yet.
-        entry.tc.write(DDT_TC::V::CLEAR + DDT_TC::EN_PRI::SET);
+        entry.tc.set(0x0);
 
-        // Check riscv stage-2 pt, root pt should be 16KiB aligned.
-        if root_pt & ((16 * 1024) - 1) != 0 {
-            error!(
-                "RV IOMMU: iohgatp root page-table is not 16KiB aligned: {:#x}",
-                root_pt
-            );
-        }
         // Configure the stage-2 page table mode same as cpu.
         let iohgatp_mode = match unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL } {
             3 => DDT_IOHGATP::MODE::SV39X4,
             4 => DDT_IOHGATP::MODE::SV48X4,
             5 => DDT_IOHGATP::MODE::SV57X4,
-            _ => panic!("Invalid stage-2 pt level: {}", unsafe {
-                crate::arch::s2pt::GSTAGE_PT_LEVEL
-            }),
+            _ => {
+                error!("RV IOMMU: Invalid stage-2 pt level: {}", unsafe {
+                    crate::arch::s2pt::GSTAGE_PT_LEVEL
+                });
+                return;
+            }
         };
+
         entry.iohgatp.write(
             DDT_IOHGATP::PPN.val((root_pt as u64) >> 12)
                 + DDT_IOHGATP::GSCID.val(vm_id as u64)
                 + iohgatp_mode,
         );
         // Bare first-stage context.
-        entry.fsc.write(DDT_FSC::MODE::BARE);
+        entry.fsc.set(0x0);
         entry.tc.write(DDT_TC::V::SET);
         info!(
             "RV IOMMU: Write DDT, add decive context, iohgatp.mode = {:#x?}, ioghatp.ppn = {:#x?}",
@@ -477,6 +527,10 @@ impl Iommu {
     }
 
     fn rv_iommu_remove_device(&mut self, device_id: usize) {
+        if device_id == 0 {
+            info!("Skip Device with device_id = 0");
+            return;
+        }
         let Some(entry) = self.ddt.get_or_alloc_leaf_entry(device_id) else {
             warn!(
                 "RV IOMMU: Invalid device ID {} for DDT mode {:?}",

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -18,215 +18,472 @@
 #![allow(unused)]
 
 use crate::memory::Frame;
-use log::{error, info};
+use alloc::vec::Vec;
+use core::sync::atomic::{fence, Ordering};
+use log::{error, info, warn};
 use spin::{Once, RwLock};
+use tock_registers::interfaces::{Readable, Writeable};
+use tock_registers::register_bitfields;
+use tock_registers::register_structs;
+use tock_registers::registers::{ReadOnly, ReadWrite};
 
-const IOMMU_MODE: usize = 0x2;
-pub const BLK_PCI_ID: usize = 0x4;
-pub const PCIE_MMIO_BEG: usize = 0x4000_0000;
-pub const PCIE_MMIO_SIZE: usize = 0x0000_0000;
-pub const PCI_MAP_BEG: usize = 0x4_0000_0000;
-pub const PCI_MAP_SIZE: usize = 0x4_0000_0000;
+#[inline(always)]
+fn io_fence() {
+    unsafe {
+        core::arch::asm!("fence iorw, iorw", options(nostack, preserves_flags));
+    }
+}
 
-// # Memory-mapped Register Interface
-//  Capabilities register fields
-const RV_IOMMU_CAPS_VERSION_MASK: usize = 0xff;
-const RV_IOMMU_CAPS_IGS_MASK: usize = 0x3 << 28;
-const RV_IOMMU_SUPPORTED_VERSION: usize = 0x10;
-const RV_IOMMU_CAPS_SV39X4_BIT: usize = 0x1 << 17;
-const RV_IOMMU_CAPS_MSI_FLAT_BIT: usize = 0x1 << 17;
-const RV_IOMMU_CAPS_AMO_HWAD_BIT: usize = 0x1 << 24;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u64)]
+pub enum IommuDdtMode {
+    Off = 0,
+    Bare = 1,
+    OneLevel = 2,
+    TwoLevel = 3,
+    ThreeLevel = 4,
+}
 
-// Features control register fields
-const RV_IOMMU_FCTL_DEFAULT: u32 = 0x1 << 1;
+// RISC-V IOMMU Spec Chap6.3 IOMMU capabilities
+register_bitfields![u64,
+    IOMMU_CAPS [
+        VERSION OFFSET(0) NUMBITS(8) [
+            VERSION_1_0 = 0x10,
+        ],
+        SV32 OFFSET(8) NUMBITS(1) [],
+        SV39 OFFSET(9) NUMBITS(1) [],
+        SV48 OFFSET(10) NUMBITS(1) [],
+        SV57 OFFSET(11) NUMBITS(1) [],
+        SVRSW60T59B OFFSET(14) NUMBITS(1) [],
+        SVPBMT OFFSET(15) NUMBITS(1) [],
+        SV32X4 OFFSET(16) NUMBITS(1) [],
+        SV39X4 OFFSET(17) NUMBITS(1) [],
+        SV48X4 OFFSET(18) NUMBITS(1) [],
+        SV57X4 OFFSET(19) NUMBITS(1) [],
+        AMO_MRIF OFFSET(21) NUMBITS(1) [],
+        MSI_FLAT OFFSET(22) NUMBITS(1) [],
+        MSI_MRIF OFFSET(23) NUMBITS(1) [],
+        AMO_HWAD OFFSET(24) NUMBITS(1) [],
+        ATS OFFSET(25) NUMBITS(1) [],
+        T2GPA OFFSET(26) NUMBITS(1) [],
+        END OFFSET(27) NUMBITS(1) [],
+        IGS OFFSET(28) NUMBITS(2) [
+            MSI = 0,
+            WSI = 1,
+            BOTH = 2,
+        ],
+        HPM OFFSET(30) NUMBITS(1) [],
+        DBG OFFSET(31) NUMBITS(1) [],
+        PAS OFFSET(32) NUMBITS(6) [],
+        PD8 OFFSET(38) NUMBITS(1) [],
+        PD17 OFFSET(39) NUMBITS(1) [],
+        PD20 OFFSET(40) NUMBITS(1) [],
+        QOS OFFSET(41) NUMBITS(1) [],
+        NL OFFSET(42) NUMBITS(1) [],
+        S OFFSET(43) NUMBITS(1) [],
+    ],
+    IOMMU_DDTP [
+        MODE OFFSET(0) NUMBITS(4) [
+            OFF = 0,
+            BARE = 1,
+            DDT_1LVL = 2,
+            DDT_2LVL = 3,
+            DDT_3LVL = 4
+        ],
+        BUSY OFFSET(4) NUMBITS(1) [],
+        PPN OFFSET(10) NUMBITS(44) []
+    ],
+    DDT_TC [
+        V OFFSET(0) NUMBITS(1) [],
+        EN_PRI OFFSET(4) NUMBITS(1) []
+    ],
+    DDT_IOHGATP [
+        PPN OFFSET(0) NUMBITS(44) [],
+        GSCID OFFSET(44) NUMBITS(16) [],
+        MODE OFFSET(60) NUMBITS(4) [
+            SV39X4 = 8,
+            SV48X4 = 9,
+            SV57X4 = 10
+        ]
+    ],
+    DDT_FSC [
+        MODE OFFSET(0) NUMBITS(4) [
+            BARE = 0
+        ]
+    ],
+    DDT_DIR [
+        V OFFSET(0) NUMBITS(1) [],
+        PPN OFFSET(10) NUMBITS(44) []
+    ]
+];
 
-// Interrupt pending register
-// const RV_IOMMU_IPSR_FIP_BIT: u32 = 1 << 1;
-const RV_IOMMU_IPSR_CLEAR: u32 = 0x0F;
+register_bitfields![u32,
+    IOMMU_FCTL [
+        BE OFFSET(0) NUMBITS(1) [],
+        WSI OFFSET(1) NUMBITS(1) [],
+        GXL OFFSET(2) NUMBITS(1) [],
+    ],
+    IOMMU_IPSR [
+        CIP OFFSET(0) NUMBITS(1) [],
+        FIP OFFSET(1) NUMBITS(1) [],
+        PMIP OFFSET(2) NUMBITS(1) [],
+        PIP OFFSET(3) NUMBITS(1) []
+    ]
+];
 
-// Interrupt Vectors
-// const RV_IOMMU_ICVEC_DEFAULT: usize = 0x1 << 4;
+// RISC-V IOMMU Specv1.0: Chap6.1 Register layout
+register_structs! {
+    #[allow(non_snake_case)]
+    IommuHw {
+        (0x000 => caps: ReadOnly<u64, IOMMU_CAPS::Register>),
+        (0x008 => fctl: ReadWrite<u32, IOMMU_FCTL::Register>),
+        (0x00c => _custom1),
+        (0x010 => ddtp: ReadWrite<u64, IOMMU_DDTP::Register>),
+        (0x018 => cqb: ReadWrite<u64>),
+        (0x020 => cqh: ReadWrite<u32>),
+        (0x024 => cqt: ReadWrite<u32>),
+        (0x028 => fqb: ReadWrite<u64>),
+        (0x030 => fqh: ReadWrite<u32>),
+        (0x034 => fqt: ReadWrite<u32>),
+        (0x038 => pqb: ReadWrite<u64>),
+        (0x040 => pqh: ReadWrite<u32>),
+        (0x044 => pqt: ReadWrite<u32>),
+        (0x048 => cqcsr: ReadWrite<u32>),
+        (0x04c => fqcsr: ReadWrite<u32>),
+        (0x050 => pqcsr: ReadWrite<u32>),
+        (0x054 => ipsr: ReadWrite<u32, IOMMU_IPSR::Register>),
+        (0x058 => iocntovf: ReadWrite<u32>),
+        (0x05c => iocntinh: ReadWrite<u32>),
+        (0x060 => iohpmcycles: ReadWrite<u64>),
+        (0x068 => iohpmctr: [ReadWrite<u64>; 31]),
+        (0x160 => iohpmevt: [ReadWrite<u64>; 31]),
+        (0x258 => tr_req_iova: ReadWrite<u64>),
+        (0x260 => tr_req_ctl: ReadWrite<u64>),
+        (0x268 => tr_response: ReadOnly<u64>),
+        (0x270 => _reserved1),
+        (0x2b0 => _custom2),
+        (0x2f8 => icvec: ReadWrite<u64>),
+        (0x300 => _msi_cfg_tbl),    // TODO: support MSI
+        (0x400 => _reserved2),
+        (0x1000 => @END),
+    }
+}
 
-// Confiure DC
-const RV_IOMMU_DC_VALID_BIT: usize = 1 << 0;
-const RV_IOMMU_IOHGATP_SV39X4: usize = 8 << 60;
-const RV_IOMMU_DC_IOHGATP_PPN_MASK: usize = 0xFFF_FFFF_FFFF;
-const RV_IOMMU_DC_IOHGATP_GSCID_MASK: usize = 0xFFFF << 44;
-const RV_IOMMU_DDTP_PPN_MASK: usize = 0xFFF_FFFF_FFFF << 10;
+/// Global IOMMU instance
+static IOMMU: Once<RwLock<Iommu>> = Once::new();
 
-pub static IOMMU: Once<RwLock<Iommu>> = Once::new();
-
-pub fn iommu<'a>() -> &'a RwLock<Iommu> {
+fn get_iommu<'a>() -> &'a RwLock<Iommu> {
     IOMMU.get().expect("Uninitialized hypervisor iommu!")
 }
 
-// alloc the Fram for DDT
+/// Initialize IOMMU with default mode
 pub fn iommu_init() {
-    let iommu = Iommu::new(crate::platform::IOMMU_SYS_BASE);
-    IOMMU.call_once(|| RwLock::new(iommu));
-    rv_iommu_init();
+    riscv_iommu_init();
 }
 
-// master CPU do!
-pub fn rv_iommu_init() {
-    let iommu = iommu();
-    let _ = iommu.write().rv_iommu_init();
-}
-
-// every DMA device do!
+/// Add a device to IOMMU
 pub fn iommu_add_device(vm_id: usize, device_id: usize, root_pt: usize) {
     info!(
         "RV_IOMMU_ADD_DEVICE: root_pt {:#x}, vm_id {}",
         root_pt, vm_id
     );
-    let iommu = iommu();
+    let iommu = get_iommu();
     iommu.write().rv_iommu_add_device(device_id, vm_id, root_pt);
 }
 
-#[repr(C)]
-#[repr(align(0x1000))]
-pub struct IommuHw {
-    caps: u64,
-    fctl: u32,
-    __custom1: [u8; 4],
-    ddtp: u64,
-    cqb: u64,
-    cqh: u32,
-    cqt: u32,
-    fqb: u64,
-    fqh: u32,
-    fqt: u32,
-    pqb: u64,
-    pqh: u32,
-    pqt: u32,
-    cqcsr: u32,
-    fqcsr: u32,
-    pqcsr: u32,
-    ipsr: u32,
-    iocntovf: u32,
-    iocntinh: u32,
-    iohpmcycles: u64,
-    iohpmctr: [u64; 31],
-    iohpmevt: [u64; 31],
-    tr_req_iova: u64,
-    tr_req_ctl: u64,
-    tr_response: u64,
-    __rsv1: [u8; 64],
-    __custom2: [u8; 72],
-    icvec: u64,
-    msi_cfg_tbl: [MsiCfgTbl; 16],
-    __rsv2: [u8; 3072],
+/// Initialize RISC-V IOMMU with hardware DDTP probing.
+fn riscv_iommu_init() {
+    assert!(crate::platform::IOMMU_SYS_SIZE == 0x1000, "IOMMU_SYS_SIZE is not 0x1000");
+    let iommu = Iommu::new(crate::platform::IOMMU_SYS_BASE);
+    IOMMU.call_once(|| RwLock::new(iommu));
+    get_iommu().write().rv_iommu_init();
 }
 
-// #define BIT64_MASK(OFF, LEN) ((((UINT64_C(1) << ((LEN)-1)) << 1) - 1) << (OFF))
-
 impl IommuHw {
-    pub fn rv_iommu_check_features(&self) {
-        let caps = self.caps as usize;
-        let version = caps & RV_IOMMU_CAPS_VERSION_MASK;
-        if version != RV_IOMMU_SUPPORTED_VERSION {
+    fn try_set_ddtp(&mut self, ddt_addr: usize, mode: IommuDdtMode) -> bool {
+        while self.ddtp.is_set(IOMMU_DDTP::BUSY) {}
+        self.ddtp.write(
+            IOMMU_DDTP::PPN.val((ddt_addr as u64) >> 12) + IOMMU_DDTP::MODE.val(mode as u64),
+        );
+        // Mode transition completes only when BUSY returns to 0.
+        while self.ddtp.is_set(IOMMU_DDTP::BUSY) {}
+        self.ddtp.read(IOMMU_DDTP::MODE) == mode as u64
+    }
+
+    fn set_ddtp(&mut self, ddt_addr: usize, requested_mode: IommuDdtMode) -> IommuDdtMode {
+        let candidates: &[IommuDdtMode] = &[
+            IommuDdtMode::ThreeLevel,
+            IommuDdtMode::TwoLevel,
+            IommuDdtMode::OneLevel,
+        ];
+        for mode in candidates {
+            if self.try_set_ddtp(ddt_addr, *mode) {
+                info!("RISC-V IOMMU: DDTP mode set to {:?}", *mode);
+                return *mode;
+            }
+        }
+        IommuDdtMode::Off
+    }
+
+    fn rv_iommu_check_features(&self) {
+        let version = self.caps.read(IOMMU_CAPS::VERSION);
+        // Stop and report failure if capabilities.version is not supported.
+        if version != IOMMU_CAPS::VERSION::VERSION_1_0.value {
             panic!(
                 "RISC-V IOMMU unsupported version: {}, Please check the IOMMU version",
                 version
             );
         }
-        if caps & RV_IOMMU_CAPS_SV39X4_BIT == 0 {
-            warn!("RISC-V IOMMU HW does not support Sv39x4");
+        // Note: here RISCV-IOMMU and CPU share the same stage-2 page table.
+        let cpu_s2pt_lvl = unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL };
+        if !self.caps.is_set(IOMMU_CAPS::SV39X4) && cpu_s2pt_lvl == 3 {
+            panic!("CPU s2pt is Sv39x4, but IOMMU does not support Sv39x4");
         }
-        if caps & RV_IOMMU_CAPS_MSI_FLAT_BIT == 0 {
-            warn!(
-                "RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)"
-            );
+        if !self.caps.is_set(IOMMU_CAPS::SV48X4) && cpu_s2pt_lvl == 4 {
+            panic!("CPU s2pt is Sv48x4, but IOMMU does not support Sv48x4");
         }
-        if caps & RV_IOMMU_CAPS_IGS_MASK == 0 {
+        if !self.caps.is_set(IOMMU_CAPS::SV57X4) && cpu_s2pt_lvl == 5 {
+            panic!("CPU s2pt is Sv57x4, but IOMMU does not support Sv57x4");
+        }
+        if !self.caps.is_set(IOMMU_CAPS::MSI_FLAT) {
+            // Current DDT Entry only supports Extented-for
+            todo!("RISC-V IOMMU HW does not support MSI Address Translation (basic-translate mode)");
+        }
+        if self.caps.read(IOMMU_CAPS::IGS) == IOMMU_CAPS::IGS::MSI.value {
             warn!("RISC-V IOMMU HW does not support WSI generation");
         }
-        if caps & RV_IOMMU_CAPS_AMO_HWAD_BIT == 0 {
-            warn!("RISC-V IOMMU HW AMO HWAD unsupport");
+    }
+
+    fn rv_iommu_init(&mut self, ddt_addr: usize, ddt_mode: IommuDdtMode) -> IommuDdtMode {
+        // RISC-V IOMMU Spec Chap7.2 Guidelines for initialization
+        // Read the capabilities register to discover the capabilities of the IOMMU.
+        self.rv_iommu_check_features();
+        // Read the feature control register(fctl).
+        self.fctl
+            .write(IOMMU_FCTL::WSI::SET + IOMMU_FCTL::BE::CLEAR + IOMMU_FCTL::GXL::CLEAR);
+        // Clear all IP flags, ipsr is RW1C (Write-1-to-clear status)
+        self.ipsr.write(
+            IOMMU_IPSR::CIP::SET
+                + IOMMU_IPSR::FIP::SET
+                + IOMMU_IPSR::PMIP::SET
+                + IOMMU_IPSR::PIP::SET,
+        );
+        // TODO: support MSI
+        // TODO: program the command queue
+        // TODO: program the fault queue
+        // TODO: program the page-request queue
+
+        // Configure ddtp with DDT base address and IOMMU mode
+        self.set_ddtp(ddt_addr, ddt_mode)
+    }
+}
+
+/// Extended-format device-context data structure.
+#[repr(C)]
+struct DdtEntry {
+    tc: ReadWrite<u64, DDT_TC::Register>,
+    iohgatp: ReadWrite<u64, DDT_IOHGATP::Register>,
+    ta: ReadWrite<u64>,
+    fsc: ReadWrite<u64, DDT_FSC::Register>,
+    msiptp: ReadWrite<u64>,
+    msi_addr_mask: ReadWrite<u64>,
+    msi_addr_pattern: ReadWrite<u64>,
+    __rsv: ReadWrite<u64>,
+}
+
+/// Intermediate device-directory table
+#[repr(C)]
+struct DdtDirTable {
+    entries: [ReadWrite<u64, DDT_DIR::Register>; 512],
+}
+
+/// Leaf device-directory table
+#[repr(C)]
+struct DdtLeafTable {
+    dc: [DdtEntry; 64], // 64 = 4KiB / sizeof(DdtEntry)
+}
+
+/// Device-directory table
+pub struct DdtRootMemory {
+    mode: IommuDdtMode,
+    root: Frame,
+    lower_levels: Vec<Frame>,
+}
+
+impl DdtRootMemory {
+    const DEV_ID_MAX: usize = (1 << 24) - 1; // device_id supports up to 24 bits
+
+    fn new() -> Self {
+        Self {
+            mode: IommuDdtMode::Off,
+            root: Frame::new_zero().unwrap(),
+            lower_levels: Vec::new(),
         }
     }
 
-    pub fn rv_iommu_init(&mut self, ddt_addr: usize) {
-        // Read and check caps
-        self.rv_iommu_check_features();
-        // Set fctl.WSI We will be first using WSI as IOMMU interrupt mechanism
-        self.fctl = RV_IOMMU_FCTL_DEFAULT;
-        // Clear all IP flags (ipsr)
-        self.ipsr = RV_IOMMU_IPSR_CLEAR;
-        // Configure ddtp with DDT base address and IOMMU mode
-        self.ddtp = IOMMU_MODE as u64 | ((ddt_addr >> 2) & RV_IOMMU_DDTP_PPN_MASK) as u64;
-        // self.ddtp = PLATFORM.iommu_mode as u64 | ddt_addr as u64;
-        // error!{"RV_IOMMU_INIT: DDTP mode {:#x}, DDT_ADDR {:#x}", PLATFORM.iommu_mode, ddt_addr};
+    fn mode(&self) -> IommuDdtMode {
+        self.mode
     }
-}
 
-#[repr(C)]
-struct MsiCfgTbl {
-    addr: u64,
-    data: u32,
-    vctl: u32,
-}
+    fn set_mode(&mut self, mode: IommuDdtMode) {
+        self.mode = mode;
+    }
 
-#[repr(C)]
-struct DdtEntry {
-    tc: u64,
-    iohgatp: u64,
-    ta: u64,
-    fsc: u64,
-    msiptp: u64,
-    msi_addr_mask: u64,
-    msi_addr_pattern: u64,
-    __rsv: u64,
-}
+    fn root_paddr(&self) -> usize {
+        self.root.start_paddr()
+    }
 
-#[repr(C)]
-pub struct Lvl1DdtHw {
-    dc: [DdtEntry; 64],
+    fn alloc_next_level_table(&mut self) -> usize {
+        let frame = Frame::new_zero().unwrap();
+        let paddr = frame.start_paddr();
+        self.lower_levels.push(frame);
+        paddr
+    }
+
+    fn dir_table_at(paddr: usize) -> &'static mut DdtDirTable {
+        unsafe { &mut *(paddr as *mut DdtDirTable) }
+    }
+
+    fn leaf_table_at(paddr: usize) -> &'static mut DdtLeafTable {
+        unsafe { &mut *(paddr as *mut DdtLeafTable) }
+    }
+
+    fn ensure_child_table(&mut self, table_paddr: usize, idx: usize) -> usize {
+        let entry = &mut Self::dir_table_at(table_paddr).entries[idx];
+        if entry.is_set(DDT_DIR::V) {
+            return (entry.read(DDT_DIR::PPN) as usize) << 12;
+        }
+        let child_paddr = self.alloc_next_level_table();
+        entry.write(DDT_DIR::V::SET + DDT_DIR::PPN.val((child_paddr as u64) >> 12));
+        child_paddr
+    }
+
+    // IOMMU.caps.MSI_FLAT should be 1.
+    // Device id split for 3-level DDT (no overlap):
+    // [23:15] -> level-1, [14:6] -> level-2, [5:0] -> level-3.
+    fn ddt_indices(device_id: usize) -> (usize, usize, usize) {
+        let l1 = (device_id >> 15) & 0x1ff;
+        let l2 = (device_id >> 6) & 0x1ff;
+        let l3 = device_id & 0x3f;
+        (l1, l2, l3)
+    }
+
+    fn get_or_alloc_leaf_entry(&mut self, device_id: usize) -> Option<&mut DdtEntry> {
+        if device_id > Self::DEV_ID_MAX {
+            return None;
+        }
+        let (l1, l2, l3) = Self::ddt_indices(device_id);
+        let leaf_table_paddr = match self.mode {
+            IommuDdtMode::OneLevel => self.root_paddr(),
+            IommuDdtMode::TwoLevel => self.ensure_child_table(self.root_paddr(), l2),
+            IommuDdtMode::ThreeLevel => {
+                let lvl2_table_paddr = self.ensure_child_table(self.root_paddr(), l1);
+                self.ensure_child_table(lvl2_table_paddr, l2)
+            }
+            _ => return None,
+        };
+        Some(&mut Self::leaf_table_at(leaf_table_paddr).dc[l3])
+    }
 }
 
 pub struct Iommu {
     pub base: usize,
-    pub ddt: Frame,
+    ddt: DdtRootMemory,
 }
 
 impl Iommu {
-    pub fn new(base: usize) -> Self {
+    fn new(base: usize) -> Self {
         Self {
-            base: base,
-            ddt: Frame::new_zero().unwrap(),
+            base,
+            ddt: DdtRootMemory::new(),
         }
     }
 
-    pub fn iommu(&self) -> &mut IommuHw {
+    fn iommu(&self) -> &mut IommuHw {
         unsafe { &mut *(self.base as *mut _) }
     }
 
-    pub fn dc(&self) -> &mut Lvl1DdtHw {
-        unsafe { &mut *(self.ddt.start_paddr() as *mut _) }
+    fn ddt_root_paddr(&self) -> usize {
+        self.ddt.root_paddr()
     }
 
-    pub fn rv_iommu_init(&mut self) {
-        self.iommu().rv_iommu_init(self.ddt.start_paddr());
+    fn ddt_mode(&self) -> IommuDdtMode {
+        self.ddt.mode()
     }
 
-    pub fn rv_iommu_add_device(&self, device_id: usize, vm_id: usize, root_pt: usize) {
-        if device_id > 0 && device_id < 64 {
-            // configure DC
-            let tc: u64 = 0 | RV_IOMMU_DC_VALID_BIT as u64 | 1 << 4;
-            self.dc().dc[device_id].tc = tc;
-            let mut iohgatp: u64 = 0;
-            iohgatp |= (root_pt as u64 >> 12) & RV_IOMMU_DC_IOHGATP_PPN_MASK as u64;
-            iohgatp |= (vm_id as u64) & RV_IOMMU_DC_IOHGATP_GSCID_MASK as u64;
-            iohgatp |= RV_IOMMU_IOHGATP_SV39X4 as u64;
-            self.dc().dc[device_id].iohgatp = iohgatp;
-            self.dc().dc[device_id].fsc = 0;
-            info!("{:#x}", &mut self.dc().dc[device_id] as *mut _ as usize);
-            info!(
-                "RV IOMMU: Write DDT, add decive context, iohgatp {:#x}",
-                iohgatp
+    fn rv_iommu_init(&mut self) {
+        // Always probe from the highest practical mode, then fallback by retention.
+        let requested_mode = IommuDdtMode::ThreeLevel;
+        let selected_mode = self
+            .iommu()
+            .rv_iommu_init(self.ddt_root_paddr(), requested_mode);
+        if selected_mode != requested_mode {
+            warn!(
+                "RV IOMMU: DDTP mode downgraded from {:?} to {:?}",
+                requested_mode, selected_mode
             );
-        } else {
-            info!("RV IOMMU: Invalid device ID: {}", device_id);
         }
+        self.ddt.set_mode(selected_mode);
+    }
+
+    fn rv_iommu_add_device(&mut self, device_id: usize, vm_id: usize, root_pt: usize) {
+        let Some(entry) = self.ddt.get_or_alloc_leaf_entry(device_id) else {
+            warn!(
+                "RV IOMMU: Invalid device ID {} for DDT mode {:?}",
+                device_id,
+                self.ddt_mode()
+            );
+            return;
+        };
+
+        // Prepare TC without publishing VALID yet.
+        entry.tc.write(DDT_TC::V::CLEAR + DDT_TC::EN_PRI::SET);
+
+        // Check riscv stage-2 pt, root pt should be 16KiB aligned.
+        if root_pt & ((16 * 1024) - 1) != 0 {
+            error!(
+                "RV IOMMU: iohgatp root page-table is not 16KiB aligned: {:#x}",
+                root_pt
+            );
+        }
+        // Configure the stage-2 page table mode same as cpu.
+        let iohgatp_mode = match unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL } {
+            3 => DDT_IOHGATP::MODE::SV39X4,
+            4 => DDT_IOHGATP::MODE::SV48X4,
+            5 => DDT_IOHGATP::MODE::SV57X4,
+            _ => panic!("Invalid stage-2 pt level: {}", unsafe { crate::arch::s2pt::GSTAGE_PT_LEVEL }),
+        };
+        entry.iohgatp.write(
+            DDT_IOHGATP::PPN.val((root_pt as u64) >> 12)
+                + DDT_IOHGATP::GSCID.val(vm_id as u64)
+                + iohgatp_mode
+        );
+        // Bare first-stage context.
+        entry.fsc.write(DDT_FSC::MODE::BARE);
+        entry.tc.write(DDT_TC::V::SET);
+        info!(
+            "RV IOMMU: Write DDT, add decive context, iohgatp.mode = {:#x?}, ioghatp.ppn = {:#x?}",
+            entry.iohgatp.read(DDT_IOHGATP::MODE),
+            entry.iohgatp.read(DDT_IOHGATP::PPN)
+        );
+        // "RV IOMMU: DDT entry updated for device {}, remember to issue IODIR/IOTINVAL commands if entry is changed while IOMMU is active"
+    }
+
+    fn rv_iommu_remove_device(&mut self, device_id: usize) {
+        let Some(entry) = self.ddt.get_or_alloc_leaf_entry(device_id) else {
+            warn!(
+                "RV IOMMU: Invalid device ID {} for DDT mode {:?}",
+                device_id,
+                self.ddt_mode()
+            );
+            return;
+        };
+        entry.tc.write(DDT_TC::V::CLEAR);
+        info!(
+            "RV IOMMU: Write DDT, remove decive context, iohgatp.mode = {:#x?}, ioghatp.ppn = {:#x?}",
+            entry.iohgatp.read(DDT_IOHGATP::MODE),
+            entry.iohgatp.read(DDT_IOHGATP::PPN)
+        );
+        // "RV IOMMU: DDT entry updated for device {}, remember to issue IODIR/IOTINVAL commands if entry is changed while IOMMU is active"
     }
 }

--- a/src/pci/pci_config.rs
+++ b/src/pci/pci_config.rs
@@ -29,6 +29,7 @@ use alloc::vec::Vec;
 
 #[cfg(any(
     all(feature = "iommu", target_arch = "aarch64"),
+    all(feature = "iommu", target_arch = "riscv64"),
     target_arch = "x86_64"
 ))]
 use crate::arch::iommu::iommu_add_device;
@@ -259,6 +260,7 @@ impl Zone {
 
                 #[cfg(any(
                     all(feature = "iommu", target_arch = "aarch64"),
+                    all(feature = "iommu", target_arch = "riscv64"),
                     target_arch = "x86_64"
                 ))]
                 {

--- a/src/pci/pci_config.rs
+++ b/src/pci/pci_config.rs
@@ -272,6 +272,9 @@ impl Zone {
                     let device_id = (dev_config.bus as usize) << 8
                         | (dev_config.device as usize) << 3
                         | dev_config.function as usize;
+                    #[cfg(feature = "share_s2pt")]
+                    iommu_add_device(_zone_id, device_id as _, inner.gpm().root_paddr());
+                    #[cfg(not(feature = "share_s2pt"))]
                     iommu_add_device(_zone_id, device_id as _, iommu_pt_addr);
                 }
 

--- a/src/pci/pci_handler.rs
+++ b/src/pci/pci_handler.rs
@@ -347,6 +347,11 @@ fn handle_endpoint_access(
                                         (vbdf.device << 3) + vbdf.function,
                                     );
                                 }
+                                #[cfg(target_arch = "riscv64")]
+                                unsafe {
+                                    // TOOD: add remote fence support (using sbi rfence spec?)
+                                    core::arch::asm!("hfence.gvma");
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR aims to add initial support for the RISC-V IOMMU to address the growing availability of RISC-V boards that support IOMMU, providing DMA remapping support. It also lays the foundation for support for vIOMMU on RISC-V.