### PR TITLE
Add benchmarking scripts for `qemu-gicv3` and `qemu-plic`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,19 +238,27 @@ perf-prepare-img: clean test-pre gen_cargo_config
 
 # Run a single perf benchmark (assumes perf image is already prepared).
 # Before test start, rebuild hvisor-tool and deploy artifacts into rootfs.
-# Usage: make ptest=irq | make ptest=net | make ptest=mem
+# Usage: make ptest=irq | make ptest=net | make ptest=mem | make ptest=blk
 ptest: ptest-check
 	./platform/$(ARCH)/$(BOARD)/test/systemtest/tcompiledtb.sh
-	./platform/$(ARCH)/$(BOARD)/test/systemtest/trootfs_deploy.sh
-	PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh
+	./platform/$(ARCH)/$(BOARD)/test/perftest/trootfs_deploy.sh
+	@if [ "$(ptest)" = "blk" ]; then \
+		expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_blk.sh; \
+	else \
+		PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh; \
+	fi
 
 # Run a single perf benchmark without image prepare step.
 ptest-only: ptest-check
-	PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh
+	@if [ "$(ptest)" = "blk" ]; then \
+		expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_blk.sh; \
+	else \
+		PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh; \
+	fi
 
 ptest-check:
 	@if [ -z "$(ptest)" ]; then \
-		echo "ERROR: ptest is empty. Use: make ptest=irq|net|mem"; \
+		echo "ERROR: ptest is empty. Use: make ptest=irq|net|mem|blk"; \
 		exit 1; \
 	fi
 	@if [ "$(BOARD)" != "qemu-plic" ] && [ "$(BOARD)" != "qemu-gicv3" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,9 @@ build_path := target/$(RUSTC_TARGET)/$(MODE)
 hvisor_elf := $(build_path)/hvisor
 hvisor_bin := $(build_path)/hvisor.bin
 image_dir  := platform/$(ARCH)/$(BOARD)/image
+test_dir := ./platform/$(ARCH)/$(BOARD)/test
+perftest_tdownload := $(test_dir)/perftest/tdownload_all.sh
+systemtest_tdownload := $(test_dir)/systemtest/tdownload_all.sh
 
 # Build arguments
 build_args := 
@@ -185,6 +188,19 @@ stest: clean test-pre gen_cargo_config
 	./platform/$(ARCH)/$(BOARD)/test/systemtest/tdownload_all.sh
 	./platform/$(ARCH)/$(BOARD)/test/systemtest/trootfs_deploy.sh
 	./platform/$(ARCH)/$(BOARD)/test/systemtest/tstart.sh
+
+# Performance benchmark: data collection only, does not affect pass/fail.
+# Calls systemtest scripts for DTS, then perftest/tdownload_all.sh when present
+# (fallback to systemtest/tdownload_all.sh), and perftest/trootfs_deploy.sh.
+perf: clean test-pre gen_cargo_config
+	./platform/$(ARCH)/$(BOARD)/test/systemtest/tcompiledtb.sh
+	@if [ -x "$(perftest_tdownload)" ]; then \
+		$(perftest_tdownload); \
+	else \
+		$(systemtest_tdownload); \
+	fi
+	./platform/$(ARCH)/$(BOARD)/test/perftest/trootfs_deploy.sh
+	./platform/$(ARCH)/$(BOARD)/test/perftest/tstart.sh
 
 dtb:
 	@echo "building device tree at platform/$(ARCH)/$(BOARD)/image/dts"

--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,33 @@ perf: clean test-pre gen_cargo_config
 	./platform/$(ARCH)/$(BOARD)/test/perftest/trootfs_deploy.sh
 	./platform/$(ARCH)/$(BOARD)/test/perftest/tstart.sh
 
+# Prepare perf image only: reuse existing rootfs img when present, download
+# missing assets, deploy benchmark scripts/tools into image, and print path.
+perf-prepare-img: clean test-pre gen_cargo_config
+	./platform/$(ARCH)/$(BOARD)/test/systemtest/tcompiledtb.sh
+	@if [ -x "$(perftest_tdownload)" ]; then \
+		$(perftest_tdownload); \
+	else \
+		$(systemtest_tdownload); \
+	fi
+	@ROOTFS_EXT4="platform/$(ARCH)/$(BOARD)/image/virtdisk/rootfs1.ext4"; \
+	 ROOTFS_ZIP="rootfs1.zip"; \
+	 if [ ! -f "$$ROOTFS_EXT4" ]; then \
+		echo "WARN: $$ROOTFS_EXT4 not found after download, trying unzip $$ROOTFS_ZIP"; \
+		if [ -f "$$ROOTFS_ZIP" ]; then \
+			unzip -qo "$$ROOTFS_ZIP" -d "platform/$(ARCH)/$(BOARD)/image/virtdisk"; \
+		else \
+			echo "ERROR: missing $$ROOTFS_EXT4 and $$ROOTFS_ZIP"; \
+			exit 1; \
+		fi; \
+	 fi; \
+	 if [ ! -f "$$ROOTFS_EXT4" ]; then \
+		echo "ERROR: still missing $$ROOTFS_EXT4 after unzip"; \
+		exit 1; \
+	 fi
+	./platform/$(ARCH)/$(BOARD)/test/perftest/trootfs_deploy.sh
+	@echo "READY_IMG=$(PWD)/platform/$(ARCH)/$(BOARD)/image/virtdisk/rootfs1.ext4"
+
 dtb:
 	@echo "building device tree at platform/$(ARCH)/$(BOARD)/image/dts"
 	@if [ ! -d "platform/$(ARCH)/$(BOARD)/image/dts" ]; then echo "ERROR: dts directory not found"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ MODE ?= debug
 BOARD ?= qemu-gicv3
 FEATURES=
 BID ?=
+ptest ?=
+
+ifeq ($(origin ptest),command line)
+ifneq ($(strip $(ptest)),)
+.DEFAULT_GOAL := ptest
+endif
+endif
 
 # if user uses `make ID=aarch64/qemu-gicv2`, we parse it into ARCH and BOARD
 ifeq ($(BID),)
@@ -228,6 +235,32 @@ perf-prepare-img: clean test-pre gen_cargo_config
 	 fi
 	./platform/$(ARCH)/$(BOARD)/test/perftest/trootfs_deploy.sh
 	@echo "READY_IMG=$(PWD)/platform/$(ARCH)/$(BOARD)/image/virtdisk/rootfs1.ext4"
+
+# Run a single perf benchmark (assumes perf image is already prepared).
+# Before test start, rebuild hvisor-tool and deploy artifacts into rootfs.
+# Usage: make ptest=irq | make ptest=net | make ptest=mem
+ptest: ptest-check
+	./platform/$(ARCH)/$(BOARD)/test/systemtest/tcompiledtb.sh
+	./platform/$(ARCH)/$(BOARD)/test/systemtest/trootfs_deploy.sh
+	PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh
+
+# Run a single perf benchmark without image prepare step.
+ptest-only: ptest-check
+	PTEST=$(ptest) expect -f ./platform/$(ARCH)/$(BOARD)/test/perftest/tstart_one.sh
+
+ptest-check:
+	@if [ -z "$(ptest)" ]; then \
+		echo "ERROR: ptest is empty. Use: make ptest=irq|net|mem"; \
+		exit 1; \
+	fi
+	@if [ "$(BOARD)" != "qemu-plic" ] && [ "$(BOARD)" != "qemu-gicv3" ]; then \
+		echo "ERROR: ptest only supports BOARD=qemu-plic|qemu-gicv3 (current: $(BOARD))"; \
+		exit 1; \
+	fi
+	@if [ "$(ptest)" != "irq" ] && [ "$(ptest)" != "net" ] && [ "$(ptest)" != "mem" ] && [ "$(ptest)" != "blk" ]; then \
+		echo "ERROR: unsupported ptest='$(ptest)'. Use irq|net|mem|blk"; \
+		exit 1; \
+	fi
 
 dtb:
 	@echo "building device tree at platform/$(ARCH)/$(BOARD)/image/dts"

--- a/platform/aarch64/qemu-gicv3/test/perftest/bench_blk.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/bench_blk.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Zone1 virtio-blk benchmark: fio preferred, dd fallback
+
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_blk.txt"
+
+echo "=== Virtio-BLK Benchmark (Zone1) ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+
+ROOT_DEV="$(findmnt -n -o SOURCE / 2>/dev/null || true)"
+if [ -n "$ROOT_DEV" ]; then
+    echo "[root device] $ROOT_DEV" | tee -a "$OUTFILE"
+fi
+
+echo "[writeback sync]" | tee -a "$OUTFILE"
+sync
+
+echo "" | tee -a "$OUTFILE"
+if command -v fio > /dev/null 2>&1; then
+    FIO_FILE="/home/arm64/test/perfresult/fio_blk_bench.dat"
+    echo "[fio seq-write 128M -> ${FIO_FILE}]" | tee -a "$OUTFILE"
+    fio --name=blk-seq-write --rw=write --bs=1M --size=128M --numjobs=1 \
+        --filename="${FIO_FILE}" --direct=1 --ioengine=libaio --iodepth=16 \
+        --end_fsync=1 --output-format=normal 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+
+    echo "[fio seq-read 128M <- ${FIO_FILE}]" | tee -a "$OUTFILE"
+    fio --name=blk-seq-read --rw=read --bs=1M --size=128M --numjobs=1 \
+        --filename="${FIO_FILE}" --direct=1 --ioengine=libaio --iodepth=16 \
+        --output-format=normal 2>&1 | tee -a "$OUTFILE"
+    rm -f "${FIO_FILE}"
+else
+    BENCH_FILE="/home/arm64/test/perfresult/hv_blk_bench.dd"
+    echo "[fio not found - fallback to dd]" | tee -a "$OUTFILE"
+    echo "[Write: dd if=/dev/zero of=${BENCH_FILE} bs=1M count=128 conv=fdatasync]" | tee -a "$OUTFILE"
+    dd if=/dev/zero of="${BENCH_FILE}" bs=1M count=128 conv=fdatasync 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+
+    echo "[Read: dd if=${BENCH_FILE} of=/dev/null bs=1M]" | tee -a "$OUTFILE"
+    dd if="${BENCH_FILE}" of=/dev/null bs=1M 2>&1 | tee -a "$OUTFILE"
+    rm -f "${BENCH_FILE}"
+fi
+
+echo "" | tee -a "$OUTFILE"
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/aarch64/qemu-gicv3/test/perftest/bench_irq.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/bench_irq.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Zone0 IRQ statistics and timer latency measurement
+# Uses cyclictest (rt-tests) when available; falls back to date-based sleep jitter
+
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_irq.txt"
+
+echo "=== IRQ / Timer Latency Benchmark ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+
+echo "[/proc/interrupts]" | tee -a "$OUTFILE"
+if [ -r /proc/interrupts ]; then
+    cat /proc/interrupts | tee -a "$OUTFILE"
+else
+    echo "/proc/interrupts unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+
+run_sleep_jitter() {
+    i=0
+    while [ $i -lt 20 ]; do
+        t1=$(date +%s%N 2>/dev/null)
+        sleep 0.01
+        t2=$(date +%s%N 2>/dev/null)
+        if echo "${t1}${t2}" | grep -qE '^[0-9]+$'; then
+            delta=$((t2 - t1))
+            echo "  sample $((i+1)): ${delta} ns  (expected ~10000000)" | tee -a "$OUTFILE"
+        else
+            echo "  sample $((i+1)): nanosecond timestamp unavailable" | tee -a "$OUTFILE"
+        fi
+        i=$((i+1))
+    done
+}
+
+if command -v cyclictest > /dev/null 2>&1; then
+    echo "[cyclictest -l 1000 -i 1000 -t 1 (interval=1ms, 1000 loops)]" | tee -a "$OUTFILE"
+    TMP_OUT=$(mktemp /tmp/hv_cyclictest.XXXXXX)
+    if cyclictest -l 1000 -i 1000 -t 1 >"$TMP_OUT" 2>&1; then
+        cat "$TMP_OUT" | tee -a "$OUTFILE"
+    else
+        cat "$TMP_OUT" | tee -a "$OUTFILE"
+        echo "[cyclictest failed — falling back to 10ms sleep jitter, 20 samples]" | tee -a "$OUTFILE"
+        run_sleep_jitter
+    fi
+    rm -f "$TMP_OUT"
+else
+    echo "[cyclictest not found — falling back to 10ms sleep jitter, 20 samples]" | tee -a "$OUTFILE"
+    run_sleep_jitter
+fi
+echo "" | tee -a "$OUTFILE"
+
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/aarch64/qemu-gicv3/test/perftest/bench_mem.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/bench_mem.sh
@@ -101,12 +101,6 @@ else
     fi
 fi
 
-echo "[/proc/meminfo]" | tee -a "$OUTFILE"
-if [ -r /proc/meminfo ]; then
-    cat /proc/meminfo | tee -a "$OUTFILE"
-else
-    echo "/proc/meminfo unavailable" | tee -a "$OUTFILE"
-fi
 echo "" | tee -a "$OUTFILE"
 
 echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/aarch64/qemu-gicv3/test/perftest/bench_mem.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/bench_mem.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Zone0 memory benchmark: stress-ng + fio when available; dd fallback
+
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_mem.txt"
+
+echo "=== Memory Benchmark ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+
+if command -v stress-ng > /dev/null 2>&1; then
+    echo "[stress-ng --vm 1 --vm-bytes 64M --vm-method all --timeout 20s --metrics-brief]" | tee -a "$OUTFILE"
+    stress-ng --vm 1 --vm-bytes 64M --vm-method all --timeout 20s --metrics-brief 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+else
+    echo "[stress-ng not found — skipping memory stress]" | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+fi
+
+if command -v fio > /dev/null 2>&1; then
+    BENCH_DIR=/tmp
+    FIO_FILE="$BENCH_DIR/fio_mem_bench"
+    AVAIL_KIB=$(df -Pk "$BENCH_DIR" 2>/dev/null | awk 'NR==2{print $4}')
+    FIO_SIZE_MIB=128
+    if [ -n "$AVAIL_KIB" ] && [ "$AVAIL_KIB" -gt 0 ] 2>/dev/null; then
+        AVAIL_MIB=$((AVAIL_KIB / 1024))
+        if [ "$AVAIL_MIB" -gt 16 ]; then
+            FIO_SIZE_MIB=$((AVAIL_MIB * 7 / 10))
+            if [ "$FIO_SIZE_MIB" -gt 128 ]; then
+                FIO_SIZE_MIB=128
+            fi
+            if [ "$FIO_SIZE_MIB" -lt 16 ]; then
+                FIO_SIZE_MIB=16
+            fi
+        elif [ "$AVAIL_MIB" -ge 10 ]; then
+            FIO_SIZE_MIB=8
+        else
+            FIO_SIZE_MIB=0
+        fi
+    fi
+
+    rm -f "${FIO_FILE}"
+    if [ "$FIO_SIZE_MIB" -eq 0 ]; then
+        echo "[fio skipped: insufficient free space on $BENCH_DIR]" | tee -a "$OUTFILE"
+        echo "" | tee -a "$OUTFILE"
+    else
+        echo "[fio seq-write ${FIO_SIZE_MIB}M -> $BENCH_DIR]" | tee -a "$OUTFILE"
+        if fio --name=seq-write --rw=write --bs=1M --size="${FIO_SIZE_MIB}M" --numjobs=1 \
+            --filename="${FIO_FILE}" --end_fsync=1 --output-format=normal 2>&1 | tee -a "$OUTFILE"; then
+            echo "" | tee -a "$OUTFILE"
+            echo "[fio seq-read ${FIO_SIZE_MIB}M <- $BENCH_DIR]" | tee -a "$OUTFILE"
+            fio --name=seq-read --rw=read --bs=1M --size="${FIO_SIZE_MIB}M" --numjobs=1 \
+                --filename="${FIO_FILE}" --output-format=normal 2>&1 | tee -a "$OUTFILE"
+        else
+            echo "" | tee -a "$OUTFILE"
+            echo "[fio write failed — skipping seq-read]" | tee -a "$OUTFILE"
+        fi
+        rm -f "${FIO_FILE}"
+        echo "" | tee -a "$OUTFILE"
+    fi
+else
+    echo "[fio not found — falling back to dd]" | tee -a "$OUTFILE"
+    BENCH_DIR=/tmp
+    BENCH_FILE="$BENCH_DIR/hv_bench_mem"
+    AVAIL_KIB=$(df -Pk "$BENCH_DIR" 2>/dev/null | awk 'NR==2{print $4}')
+    DD_COUNT_MIB=64
+    if [ -n "$AVAIL_KIB" ] && [ "$AVAIL_KIB" -gt 0 ] 2>/dev/null; then
+        AVAIL_MIB=$((AVAIL_KIB / 1024))
+        if [ "$AVAIL_MIB" -gt 16 ]; then
+            DD_COUNT_MIB=$((AVAIL_MIB * 7 / 10))
+            if [ "$DD_COUNT_MIB" -gt 64 ]; then
+                DD_COUNT_MIB=64
+            fi
+            if [ "$DD_COUNT_MIB" -lt 8 ]; then
+                DD_COUNT_MIB=8
+            fi
+        elif [ "$AVAIL_MIB" -ge 10 ]; then
+            DD_COUNT_MIB=8
+        else
+            DD_COUNT_MIB=0
+        fi
+    fi
+
+    rm -f "$BENCH_FILE"
+    if [ "$DD_COUNT_MIB" -eq 0 ]; then
+        echo "[dd skipped: insufficient free space on $BENCH_DIR]" | tee -a "$OUTFILE"
+        echo "" | tee -a "$OUTFILE"
+    else
+        echo "[Write: dd if=/dev/zero of=$BENCH_FILE bs=1M count=$DD_COUNT_MIB conv=fdatasync]" | tee -a "$OUTFILE"
+        if dd if=/dev/zero of="$BENCH_FILE" bs=1M count="$DD_COUNT_MIB" conv=fdatasync 2>&1 | tee -a "$OUTFILE"; then
+            echo "" | tee -a "$OUTFILE"
+            echo "[Read: dd if=$BENCH_FILE of=/dev/null bs=1M]" | tee -a "$OUTFILE"
+            dd if="$BENCH_FILE" of=/dev/null bs=1M 2>&1 | tee -a "$OUTFILE"
+        else
+            echo "" | tee -a "$OUTFILE"
+            echo "[dd write failed — skipping read]" | tee -a "$OUTFILE"
+        fi
+        echo "" | tee -a "$OUTFILE"
+        rm -f "$BENCH_FILE"
+    fi
+fi
+
+echo "[/proc/meminfo]" | tee -a "$OUTFILE"
+if [ -r /proc/meminfo ]; then
+    cat /proc/meminfo | tee -a "$OUTFILE"
+else
+    echo "/proc/meminfo unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/aarch64/qemu-gicv3/test/perftest/bench_net.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/bench_net.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+# Zone0 virtio-net benchmark: RTT ping + iperf3 loopback throughput
+
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_net.txt"
+GATEWAY="10.0.2.2"
+
+echo "=== Network Benchmark (zone0) ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+
+echo "[/proc/net/dev]" | tee -a "$OUTFILE"
+if [ -r /proc/net/dev ]; then
+    cat /proc/net/dev | tee -a "$OUTFILE"
+else
+    echo "/proc/net/dev unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+
+echo "[ping ${GATEWAY} -c 50 -i 0.02]" | tee -a "$OUTFILE"
+PING_LOG=$(mktemp /tmp/hv_ping.XXXXXX)
+if ping -c 50 -i 0.02 "$GATEWAY" >"$PING_LOG" 2>&1; then
+    cat "$PING_LOG" | tee -a "$OUTFILE"
+    echo "ping completed" | tee -a "$OUTFILE"
+else
+    cat "$PING_LOG" | tee -a "$OUTFILE"
+    echo "ping failed or network not available" | tee -a "$OUTFILE"
+fi
+rm -f "$PING_LOG"
+echo "" | tee -a "$OUTFILE"
+
+echo "[loopback readiness]" | tee -a "$OUTFILE"
+if command -v ip > /dev/null 2>&1; then
+    ip link set lo up >/dev/null 2>&1 || true
+    echo "attempted: ip link set lo up" | tee -a "$OUTFILE"
+elif command -v ifconfig > /dev/null 2>&1; then
+    ifconfig lo up >/dev/null 2>&1 || true
+    echo "attempted: ifconfig lo up" | tee -a "$OUTFILE"
+else
+    echo "no ip/ifconfig command, cannot explicitly bring up lo" | tee -a "$OUTFILE"
+fi
+
+LO_LOG=$(mktemp /tmp/hv_lo_ping.XXXXXX)
+if ping -c 1 127.0.0.1 >"$LO_LOG" 2>&1; then
+    cat "$LO_LOG" | tee -a "$OUTFILE"
+    LO_READY=1
+else
+    cat "$LO_LOG" | tee -a "$OUTFILE"
+    LO_READY=0
+fi
+rm -f "$LO_LOG"
+echo "" | tee -a "$OUTFILE"
+
+if command -v iperf3 > /dev/null 2>&1; then
+    if [ "$LO_READY" -eq 1 ]; then
+        echo "[iperf3 loopback: server on 127.0.0.1:5201, duration 10s]" | tee -a "$OUTFILE"
+        IPERF_SRV_LOG=$(mktemp /tmp/hv_iperf3_srv.XXXXXX)
+        IPERF_CLI_LOG=$(mktemp /tmp/hv_iperf3_cli.XXXXXX)
+        iperf3 -s -p 5201 >"$IPERF_SRV_LOG" 2>&1 &
+        IPERF_PID=$!
+        sleep 1
+        if ! kill -0 "$IPERF_PID" 2>/dev/null; then
+            echo "iperf3 server start failed" | tee -a "$OUTFILE"
+            cat "$IPERF_SRV_LOG" | tee -a "$OUTFILE"
+        else
+            if iperf3 -c 127.0.0.1 -p 5201 -t 10 >"$IPERF_CLI_LOG" 2>&1; then
+                cat "$IPERF_CLI_LOG" | tee -a "$OUTFILE"
+                echo "iperf3 loopback completed" | tee -a "$OUTFILE"
+            else
+                cat "$IPERF_CLI_LOG" | tee -a "$OUTFILE"
+                echo "iperf3 client failed" | tee -a "$OUTFILE"
+            fi
+        fi
+        kill "$IPERF_PID" 2>/dev/null || true
+        wait "$IPERF_PID" 2>/dev/null || true
+        rm -f "$IPERF_SRV_LOG" "$IPERF_CLI_LOG"
+    else
+        echo "loopback not ready, skipping iperf3 loopback test" | tee -a "$OUTFILE"
+    fi
+else
+    echo "[iperf3 not found — skipping throughput test]" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/aarch64/qemu-gicv3/test/perftest/tdownload_all.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/tdownload_all.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# perftest wrapper for aarch64/qemu-gicv3
+set -e
+
+WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+"${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/test/systemtest/tdownload_all.sh"

--- a/platform/aarch64/qemu-gicv3/test/perftest/trootfs_deploy.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/trootfs_deploy.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+set -e
+set -x
+
+WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+PERF_DIR="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/test/perftest"
+ROOTFS_EXT4="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/image/virtdisk/rootfs1.ext4"
+ROOTFS_MNT="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/image/virtdisk/rootfs"
+
+# Cleanup: unmount bind mounts and rootfs on any exit (error or normal)
+cleanup() {
+    sudo umount "${ROOTFS_MNT}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/var/lib/apt/lists"      2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/sys"  2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/proc" 2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/dev"  2>/dev/null || true
+    [ -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static" ] && \
+        sudo rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static" || true
+    sudo umount "${ROOTFS_MNT}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Remove stale mounts before invoking systemtest deploy.
+cleanup
+
+resolve_rootfs2_in_rootfs1() {
+    if [ -f "${ROOTFS_MNT}/home/arm64/rootfs2.ext4" ]; then
+        ROOTFS2_IN_ROOTFS1="${ROOTFS_MNT}/home/arm64/rootfs2.ext4"
+    elif [ -f "${ROOTFS_MNT}/rootfs2.ext4" ]; then
+        ROOTFS2_IN_ROOTFS1="${ROOTFS_MNT}/rootfs2.ext4"
+    else
+        echo "ERROR: rootfs2.ext4 not found inside rootfs1.ext4" >&2
+        exit 1
+    fi
+
+    echo "=== rootfs2 image in rootfs1: ${ROOTFS2_IN_ROOTFS1} ==="
+}
+
+# Expand an ext2/ext3/ext4 image file in-place if free space is below min_free_mb.
+# Must be called while the image is NOT mounted.
+expand_ext2_if_needed() {
+    local img="$1"
+    local min_free_mb="${2:-1024}"
+
+    local info block_size free_blocks free_mb
+    info=$(sudo dumpe2fs -h "${img}" 2>/dev/null) || {
+        echo "WARN: cannot read ${img}, skipping expand" >&2; return 0
+    }
+    block_size=$(echo "${info}" | awk '/^Block size:/{print $3}')
+    free_blocks=$(echo "${info}" | awk '/^Free blocks:/{gsub(/,/,"",$3); print $3}')
+    if [ -z "${block_size}" ] || [ -z "${free_blocks}" ]; then
+        echo "WARN: could not parse free space in ${img}, skipping expand" >&2
+        return 0
+    fi
+    free_mb=$(( (block_size * free_blocks) / 1024 / 1024 ))
+    echo "=== ${img}: ${free_mb}MB free (need ${min_free_mb}MB) ==="
+    if [ "${free_mb}" -ge "${min_free_mb}" ]; then
+        return 0
+    fi
+
+    local add_mb=$(( min_free_mb - free_mb + 128 ))
+    echo "=== Expanding ${img} by +${add_mb}MB ==="
+    sudo truncate --size=+${add_mb}M "${img}"
+    sudo e2fsck -f -y "${img}" || true
+    sudo resize2fs "${img}"
+    echo "=== Expansion done ==="
+}
+
+ensure_tools_in_rootfs() {
+    local mnt="$1"
+    local mode="${2:-strict}"
+
+    if [ -f "${mnt}/usr/bin/fio" ] && \
+       [ -f "${mnt}/usr/bin/cyclictest" ] && \
+       [ -f "${mnt}/usr/bin/stress-ng" ] && \
+       [ -f "${mnt}/usr/bin/iperf3" ]; then
+        echo "=== Benchmarking tools already installed in ${mnt}, skipping apt install ==="
+        return
+    fi
+
+    # Same chroot apt method as zone0/rootfs1; rootfs2 can be optional.
+    echo "=== Installing benchmarking tools in ${mnt} via chroot (mode=${mode}) ==="
+    QEMU_STATIC="/usr/bin/qemu-aarch64-static"
+    local rc=0
+
+    # Bind-mount host tmpdirs for apt cache/lists so that large index files
+    # do not consume guest rootfs space (avoids "No space left on device" for apt-get update).
+    local apt_lists_tmp apt_cache_tmp
+    apt_lists_tmp=$(mktemp -d)
+    apt_cache_tmp=$(mktemp -d)
+
+    if [ -f "$QEMU_STATIC" ]; then
+        sudo cp "$QEMU_STATIC" "${mnt}/usr/bin/qemu-aarch64-static"
+    fi
+    sudo mount --bind /dev   "${mnt}/dev"
+    sudo mount --bind /proc  "${mnt}/proc"
+    sudo mount --bind /sys   "${mnt}/sys"
+    sudo mkdir -p "${mnt}/var/lib/apt/lists" "${mnt}/var/cache/apt/archives"
+    sudo mount --bind "${apt_lists_tmp}" "${mnt}/var/lib/apt/lists"
+    sudo mount --bind "${apt_cache_tmp}" "${mnt}/var/cache/apt/archives"
+
+    set +e
+    sudo chroot "${mnt}" sh -c \
+        "apt-get update && apt-get install -y --no-install-recommends ${bench_tools[*]}"
+    rc=$?
+    set -e
+
+    sudo umount "${mnt}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${mnt}/var/lib/apt/lists"      2>/dev/null || true
+    rm -rf "${apt_lists_tmp}" "${apt_cache_tmp}"
+    sudo umount "${mnt}/sys"
+    sudo umount "${mnt}/proc"
+    sudo umount "${mnt}/dev"
+    sudo rm -f "${mnt}/usr/bin/qemu-aarch64-static"
+
+    if [ $rc -ne 0 ]; then
+        if [ "${mode}" = "optional" ]; then
+            echo "WARN: apt install failed in ${mnt}, continue with existing tools / benchmark fallback." >&2
+            return 0
+        fi
+        echo "ERROR: apt install failed in ${mnt}" >&2
+        return $rc
+    fi
+
+    echo "=== chroot install done for ${mnt} ==="
+}
+
+# Step 1: run the original systemtest deploy (hvisor, hvisor.ko, dtb, json, test scripts)
+echo "=== Running base systemtest deploy ==="
+"${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/test/systemtest/trootfs_deploy.sh"
+
+# Step 2: mount rootfs again and deploy bench scripts + install tools
+echo "=== Mounting rootfs ==="
+sudo mkdir -p "${ROOTFS_MNT}"
+sudo mount "${ROOTFS_EXT4}" "${ROOTFS_MNT}"
+
+# Step 3: install benchmarking tools via chroot (apt-get) — skip if already present
+if [ -f "${ROOTFS_MNT}/usr/bin/fio" ] && \
+   [ -f "${ROOTFS_MNT}/usr/bin/cyclictest" ] && \
+   [ -f "${ROOTFS_MNT}/usr/bin/stress-ng" ] && \
+   [ -f "${ROOTFS_MNT}/usr/bin/iperf3" ]; then
+    echo "=== Benchmarking tools already installed in rootfs, skipping apt install ==="
+else
+    echo "=== Installing benchmarking tools via chroot ==="
+    QEMU_STATIC="/usr/bin/qemu-aarch64-static"
+    if [ -f "$QEMU_STATIC" ]; then
+        sudo cp "$QEMU_STATIC" "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
+    fi
+    sudo mount --bind /dev   "${ROOTFS_MNT}/dev"
+    sudo mount --bind /proc  "${ROOTFS_MNT}/proc"
+    sudo mount --bind /sys   "${ROOTFS_MNT}/sys"
+    sudo chroot "${ROOTFS_MNT}" sh -c \
+        "apt-get update && apt-get install -y --no-install-recommends fio rt-tests stress-ng iperf3 iproute2"
+    sudo umount "${ROOTFS_MNT}/sys"
+    sudo umount "${ROOTFS_MNT}/proc"
+    sudo umount "${ROOTFS_MNT}/dev"
+    sudo rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
+    echo "=== chroot install done ==="
+fi
+
+# Step 4: deploy bench scripts into guest
+echo "=== Deploying perf bench scripts ==="
+BENCH_DEST="${ROOTFS_MNT}/home/arm64/test/bench"
+sudo mkdir -p "${BENCH_DEST}"
+sudo cp -v "${PERF_DIR}"/bench_*.sh "${BENCH_DEST}/"
+sudo chmod +x "${BENCH_DEST}"/bench_*.sh
+sudo mkdir -p "${ROOTFS_MNT}/home/arm64/test/perfresult"
+
+echo "=== Bench scripts deployed ==="
+sudo find "${ROOTFS_MNT}/home/arm64/test" -ls
+
+sudo umount "${ROOTFS_MNT}"
+trap - EXIT
+echo "=== perftest rootfs deploy done ==="

--- a/platform/aarch64/qemu-gicv3/test/perftest/trootfs_deploy.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/trootfs_deploy.sh
@@ -6,6 +6,10 @@ WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
 PERF_DIR="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/test/perftest"
 ROOTFS_EXT4="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/image/virtdisk/rootfs1.ext4"
 ROOTFS_MNT="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/image/virtdisk/rootfs"
+ROOTFS2_MNT="${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/image/virtdisk/rootfs2"
+ROOTFS2_IN_ROOTFS1=""
+
+bench_tools=(fio rt-tests stress-ng iperf3 iproute2)
 
 # Cleanup: unmount bind mounts and rootfs on any exit (error or normal)
 cleanup() {
@@ -14,8 +18,16 @@ cleanup() {
     sudo umount "${ROOTFS_MNT}/sys"  2>/dev/null || true
     sudo umount "${ROOTFS_MNT}/proc" 2>/dev/null || true
     sudo umount "${ROOTFS_MNT}/dev"  2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/var/lib/apt/lists"      2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/sys"  2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/proc" 2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/dev"  2>/dev/null || true
     [ -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static" ] && \
         sudo rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static" || true
+    [ -f "${ROOTFS2_MNT}/usr/bin/qemu-aarch64-static" ] && \
+        sudo rm -f "${ROOTFS2_MNT}/usr/bin/qemu-aarch64-static" || true
+    sudo umount "${ROOTFS2_MNT}" 2>/dev/null || true
     sudo umount "${ROOTFS_MNT}" 2>/dev/null || true
 }
 trap cleanup EXIT
@@ -129,46 +141,44 @@ ensure_tools_in_rootfs() {
 echo "=== Running base systemtest deploy ==="
 "${WORKSPACE_ROOT}/platform/aarch64/qemu-gicv3/test/systemtest/trootfs_deploy.sh"
 
-# Step 2: mount rootfs again and deploy bench scripts + install tools
-echo "=== Mounting rootfs ==="
+# Step 2: mount rootfs1 and deploy zone0 bench scripts + install tools
+echo "=== Mounting rootfs1 ==="
 sudo mkdir -p "${ROOTFS_MNT}"
 sudo mount "${ROOTFS_EXT4}" "${ROOTFS_MNT}"
 
-# Step 3: install benchmarking tools via chroot (apt-get) — skip if already present
-if [ -f "${ROOTFS_MNT}/usr/bin/fio" ] && \
-   [ -f "${ROOTFS_MNT}/usr/bin/cyclictest" ] && \
-   [ -f "${ROOTFS_MNT}/usr/bin/stress-ng" ] && \
-   [ -f "${ROOTFS_MNT}/usr/bin/iperf3" ]; then
-    echo "=== Benchmarking tools already installed in rootfs, skipping apt install ==="
-else
-    echo "=== Installing benchmarking tools via chroot ==="
-    QEMU_STATIC="/usr/bin/qemu-aarch64-static"
-    if [ -f "$QEMU_STATIC" ]; then
-        sudo cp "$QEMU_STATIC" "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
-    fi
-    sudo mount --bind /dev   "${ROOTFS_MNT}/dev"
-    sudo mount --bind /proc  "${ROOTFS_MNT}/proc"
-    sudo mount --bind /sys   "${ROOTFS_MNT}/sys"
-    sudo chroot "${ROOTFS_MNT}" sh -c \
-        "apt-get update && apt-get install -y --no-install-recommends fio rt-tests stress-ng iperf3 iproute2"
-    sudo umount "${ROOTFS_MNT}/sys"
-    sudo umount "${ROOTFS_MNT}/proc"
-    sudo umount "${ROOTFS_MNT}/dev"
-    sudo rm -f "${ROOTFS_MNT}/usr/bin/qemu-aarch64-static"
-    echo "=== chroot install done ==="
-fi
+ensure_tools_in_rootfs "${ROOTFS_MNT}"
 
-# Step 4: deploy bench scripts into guest
-echo "=== Deploying perf bench scripts ==="
+# Step 3: deploy zone0 bench scripts into rootfs1
+echo "=== Deploying zone0 perf scripts to rootfs1 ==="
 BENCH_DEST="${ROOTFS_MNT}/home/arm64/test/bench"
 sudo mkdir -p "${BENCH_DEST}"
-sudo cp -v "${PERF_DIR}"/bench_*.sh "${BENCH_DEST}/"
+sudo cp -v "${PERF_DIR}/bench_mem.sh" "${PERF_DIR}/bench_irq.sh" "${PERF_DIR}/bench_net.sh" "${BENCH_DEST}/"
 sudo chmod +x "${BENCH_DEST}"/bench_*.sh
 sudo mkdir -p "${ROOTFS_MNT}/home/arm64/test/perfresult"
 
-echo "=== Bench scripts deployed ==="
+echo "=== rootfs1 perf scripts deployed ==="
 sudo find "${ROOTFS_MNT}/home/arm64/test" -ls
 
+# Step 4: mount rootfs2 image from inside rootfs1
+resolve_rootfs2_in_rootfs1
+# Expand rootfs2 before mounting if free space is insufficient for apt install
+expand_ext2_if_needed "${ROOTFS2_IN_ROOTFS1}"
+echo "=== Mounting rootfs2 (embedded in rootfs1) ==="
+sudo mkdir -p "${ROOTFS2_MNT}"
+sudo mount "${ROOTFS2_IN_ROOTFS1}" "${ROOTFS2_MNT}"
+
+# Step 5: deploy zone1 blk script + install tools into embedded rootfs2
+echo "=== Installing tools and deploying zone1 blk perf script to rootfs2 ==="
+
+ensure_tools_in_rootfs "${ROOTFS2_MNT}" optional
+
+sudo mkdir -p "${ROOTFS2_MNT}/home/arm64/test/bench"
+sudo mkdir -p "${ROOTFS2_MNT}/home/arm64/test/perfresult"
+sudo cp -v "${PERF_DIR}/bench_blk.sh" "${ROOTFS2_MNT}/home/arm64/test/bench/"
+sudo chmod +x "${ROOTFS2_MNT}/home/arm64/test/bench/bench_blk.sh"
+sudo find "${ROOTFS2_MNT}/home/arm64/test" -ls
+
+sudo umount "${ROOTFS2_MNT}"
 sudo umount "${ROOTFS_MNT}"
 trap - EXIT
 echo "=== perftest rootfs deploy done ==="

--- a/platform/aarch64/qemu-gicv3/test/perftest/tstart.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/tstart.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/expect -f
+
+# aarch64/qemu-gicv3 performance benchmark driver
+# Runs zone0 mem/irq/net benchmarks and zone1 startup timing.
+# Data collection only (no benchmark pass/fail assertion); exits non-zero on infra/timeout failures.
+
+set env(LANG) "en_US.UTF-8"
+send_user "\r============ hvisor Performance Benchmark (aarch64/qemu-gicv3) ============\r"
+set run_exited_unexpectedly 1
+
+set qemu_match "qemu-system-aarch64.*platform/aarch64/qemu-gicv3/image/virtdisk/rootfs1.ext4"
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+# Clear stale QEMU from previous interrupted runs to avoid image lock.
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly (likely QEMU start failure or image lock)"
+    }
+}
+
+# ── Stage 1: U-Boot → bootm ──
+expect {
+    -re "(1 bootflow, 1 valid).*=>" {
+        send "bootm 0x40400000 - 0x40000000\r"
+    }
+    timeout {
+        fail "U-Boot prompt timeout"
+    }
+}
+
+# ── Stage 2: Zone0 shell ──
+expect {
+    -re {job control turned off.*#} {
+        send "bash\r"
+    }
+    timeout {
+        fail "zone0 shell timeout"
+    }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/arm64\r"
+    }
+    timeout { fail "zone0 cd /home/arm64 timeout" }
+}
+
+expect {
+    "root@(none):/home/arm64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "mkdir test/perfresult timeout" }
+}
+
+expect {
+    "root@(none):/home/arm64# " {
+        send "mount -t proc proc /proc 2>/dev/null || true; mount -t sysfs sysfs /sys 2>/dev/null || true; mkdir -p /dev/shm; mount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\r"
+    }
+    timeout { fail "prepare /proc /sys /dev/shm timeout" }
+}
+
+# ── Stage 3: Zone0 memory benchmark ──
+send_user "\n\n============ Zone0: Memory Benchmark ============\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "./test/bench/bench_mem.sh\r"
+    }
+    timeout { fail "bench_mem start timeout" }
+}
+set timeout 600
+expect {
+    "=== Done ===" { send_user "\n\[mem bench done\]\n" }
+    "root@(none):/home/arm64# " { fail "bench_mem exited without done marker" }
+    timeout {
+        fail "bench_mem timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 4: Zone0 IRQ / timer latency benchmark ──
+send_user "\n\n============ Zone0: IRQ / Timer Latency Benchmark ============\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "./test/bench/bench_irq.sh\r"
+    }
+    timeout { fail "bench_irq start timeout" }
+}
+set timeout 120
+expect {
+    "=== Done ===" { send_user "\n\[irq bench done\]\n" }
+    timeout {
+        fail "bench_irq timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 5: Zone0 network benchmark ──
+send_user "\n\n============ Zone0: Network Benchmark ============\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "./test/bench/bench_net.sh\r"
+    }
+    timeout { fail "bench_net start timeout" }
+}
+set timeout 120
+expect {
+    "=== Done ===" { send_user "\n\[net bench done\]\n" }
+    timeout {
+        fail "bench_net timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 6: Load hvisor kernel module ──
+send_user "\n\n============ Loading hvisor.ko ============\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "insmod hvisor.ko\r"
+    }
+    timeout { fail "insmod hvisor.ko timeout" }
+}
+expect {
+    "root@(none):/home/arm64# " {
+        # send "dmesg | tail -n 2 | awk -F ']' '{print \$2}' > ./test/testresult/test_insmod.txt\r"
+        send "./test/textract_dmesg.sh ./test/testresult/test_insmod.txt\r"
+    }
+    timeout {
+        fail "extract insmod dmesg timeout"
+    }
+}
+
+# ── Stage 7: Start zone1 and measure startup time ──
+send_user "\n\n============ Zone1: Startup Time Measurement ============\n"
+set zone1_start [clock milliseconds]
+expect {
+    "root@(none):/home/arm64# " {
+        send "./boot_zone1.sh\r"
+    }
+    timeout { fail "boot_zone1 start timeout" }
+}
+expect {
+    -re {Script started.*#} {
+        send "bash\r"
+    }
+    timeout {
+        fail "zone1 boot timeout"
+    }
+}
+set zone1_end [clock milliseconds]
+set zone1_startup_ms [expr {$zone1_end - $zone1_start}]
+send_user "\nzone1 startup time: ${zone1_startup_ms} ms\n"
+
+# ── Stage 8: Shutting down zone1 ──
+expect {
+    "root@(none):/home/arm64# " {
+        send "./hvisor zone shutdown -id 1\r"
+    }
+    timeout {
+        fail "zone1 shutdown timeout"
+    }
+}
+
+# ── Stage 9: Print summary ──
+send_user "\n\n============ Benchmark Summary ============\n"
+send_user "Zone1 startup time: ${zone1_startup_ms} ms\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "echo '--- perf results ---' && cat test/perfresult/*.txt 2>/dev/null || echo '(no result files in zone0 perfresult)'\r"
+        send_user "\n============ hvisor Performance Benchmark Finished ============\n"
+        set run_exited_unexpectedly 0
+        send "\x01x"
+        set timeout 20
+        expect {
+            eof {}
+            timeout {}
+        }
+        catch {close}
+        catch {wait}
+        exit 0
+    }
+    timeout { fail "print benchmark summary timeout" }
+}

--- a/platform/aarch64/qemu-gicv3/test/perftest/tstart_blk.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/tstart_blk.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/expect -f
+
+# aarch64/qemu-gicv3 standalone virtio-blk benchmark driver (zone1)
+# Runs zone1 startup + screen enter + bench_blk + shutdown.
+
+set env(LANG) "en_US.UTF-8"
+send_user "\r============ hvisor Virtio-BLK Benchmark (aarch64/qemu-gicv3) ============\r"
+set run_exited_unexpectedly 1
+
+set qemu_match "qemu-system-aarch64.*platform/aarch64/qemu-gicv3/image/virtdisk/rootfs1.ext4"
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+# Clear stale QEMU from previous interrupted runs to avoid image lock.
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly (likely QEMU start failure or image lock)"
+    }
+}
+
+expect {
+    -re "(1 bootflow, 1 valid).*=>" {
+        send "bootm 0x40400000 - 0x40000000\r"
+    }
+    timeout { fail "U-Boot prompt timeout" }
+}
+
+expect {
+    -re {job control turned off.*#} {
+        send "bash\r"
+    }
+    timeout { fail "zone0 shell timeout" }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/arm64\r"
+    }
+    timeout { fail "zone0 cd /home/arm64 timeout" }
+}
+
+expect {
+    "root@(none):/home/arm64# " {
+        send "insmod hvisor.ko\r"
+    }
+    timeout { fail "insmod hvisor.ko timeout" }
+}
+
+send_user "\n\n============ Zone1: Startup Time Measurement ============\n"
+set zone1_start [clock milliseconds]
+expect {
+    "root@(none):/home/arm64# " {
+        send "./boot_zone1.sh\r"
+    }
+    timeout { fail "boot_zone1 start timeout" }
+}
+expect {
+    -re {Script started.*#} {
+        send "bash\r"
+    }
+    timeout { fail "zone1 boot timeout" }
+}
+set zone1_end [clock milliseconds]
+set zone1_startup_ms [expr {$zone1_end - $zone1_start}]
+send_user "\nzone1 startup time: ${zone1_startup_ms} ms\n"
+
+send_user "\n\n============ Zone1: Virtio-BLK Benchmark ============\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send "./screen_zone1.sh\r"
+        send "\r"
+    }
+    timeout { fail "screen_zone1 start timeout" }
+}
+expect {
+    -re {\r?\n# } {
+        send "bash\r"
+    }
+    timeout { fail "zone1 shell timeout" }
+}
+expect {
+    "root@(none):/# " {
+        send "cd /home/arm64\r"
+    }
+    timeout { fail "zone1 cd /home/arm64 timeout" }
+}
+expect {
+    "root@(none):/home/arm64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "zone1 mkdir test/perfresult timeout" }
+}
+expect {
+    "root@(none):/home/arm64# " {
+        send "./test/bench/bench_blk.sh\r"
+    }
+    timeout { fail "bench_blk start timeout" }
+}
+set timeout 300
+expect {
+    "=== Done ===" { send_user "\n\[blk bench done\]\n" }
+    timeout { fail "bench_blk timeout" }
+}
+set timeout 600
+expect {
+    "root@(none):/home/arm64# " {
+        send "echo '--- blk result (zone1) ---' && cat test/perfresult/bench_blk.txt 2>/dev/null || true\r"
+    }
+    timeout { fail "bench_blk result print timeout" }
+}
+expect {
+    "root@(none):/home/arm64# " {
+        send "\x01\x01d"
+    }
+    timeout { fail "zone1 screen detach timeout" }
+}
+expect {
+    "root@(none):/home/arm64# " {
+        send "./hvisor zone shutdown -id 1\r"
+    }
+    timeout { fail "zone1 shutdown timeout" }
+}
+
+send_user "\n\n============ Virtio-BLK Benchmark Summary ============\n"
+send_user "Zone1 startup time: ${zone1_startup_ms} ms\n"
+expect {
+    "root@(none):/home/arm64# " {
+        send_user "\n============ hvisor Virtio-BLK Benchmark Finished ============\n"
+        set run_exited_unexpectedly 0
+        send "\x01x"
+        set timeout 20
+        expect {
+            eof {}
+            timeout {}
+        }
+        catch {close}
+        catch {wait}
+        exit 0
+    }
+    timeout { fail "final summary timeout" }
+}

--- a/platform/aarch64/qemu-gicv3/test/perftest/tstart_one.sh
+++ b/platform/aarch64/qemu-gicv3/test/perftest/tstart_one.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/expect -f
+
+# aarch64/qemu-gicv3 single benchmark driver
+# Usage: PTEST=mem|irq|net|blk expect -f tstart_one.sh
+
+set env(LANG) "en_US.UTF-8"
+set run_exited_unexpectedly 1
+set qemu_match "qemu-system-aarch64.*platform/aarch64/qemu-gicv3/image/virtdisk/rootfs1.ext4"
+
+set ptest ""
+if {[info exists env(PTEST)]} {
+    set ptest $env(PTEST)
+}
+if {$ptest eq ""} {
+    send_user "ERROR: PTEST is empty, use mem|irq|net|blk\n"
+    exit 1
+}
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+proc run_bench {name cmd timeout_sec result_file} {
+    send_user "\n\n============ Zone0: $name Benchmark ============\n"
+    expect {
+        "root@(none):/home/arm64# " {
+            send "$cmd\r"
+        }
+        timeout { fail "$name start timeout" }
+    }
+    set timeout $timeout_sec
+    expect {
+        "=== Done ===" { send_user "\n\[$name bench done\]\n" }
+        "root@(none):/home/arm64# " { fail "$name exited without done marker" }
+        timeout { fail "$name timeout" }
+    }
+    set timeout 600
+    expect {
+        "root@(none):/home/arm64# " {
+            send "echo '--- $name result ---' && cat $result_file 2>/dev/null || true\r"
+        }
+        timeout { fail "$name result print timeout" }
+    }
+}
+
+proc run_blk_bench_in_zone1 {} {
+    send_user "\n\n============ Zone1: Virtio-BLK Benchmark ============\n"
+
+    expect {
+        "root@(none):/home/arm64# " {
+            send "insmod hvisor.ko\r"
+        }
+        timeout { fail "insmod hvisor.ko timeout" }
+    }
+
+    expect {
+        "root@(none):/home/arm64# " {
+            send "./boot_zone1.sh\r"
+        }
+        timeout { fail "boot_zone1 start timeout" }
+    }
+    expect {
+        -re {Script started.*#} {
+            send "bash\r"
+        }
+        timeout { fail "zone1 boot timeout" }
+    }
+
+    expect {
+        "root@(none):/home/arm64# " {
+            send "./screen_zone1.sh\r"
+            send "\r"
+        }
+        timeout { fail "screen_zone1 start timeout" }
+    }
+    expect {
+        -re {\r?\n# } {
+            send "bash\r"
+        }
+        timeout { fail "zone1 shell timeout" }
+    }
+    expect {
+        "root@(none):/# " {
+            send "cd /home/arm64\r"
+        }
+        timeout { fail "zone1 cd /home/arm64 timeout" }
+    }
+    expect {
+        "root@(none):/home/arm64# " {
+            send "mkdir -p test/perfresult\r"
+        }
+        timeout { fail "zone1 mkdir test/perfresult timeout" }
+    }
+    expect {
+        "root@(none):/home/arm64# " {
+            send "./test/bench/bench_blk.sh\r"
+        }
+        timeout { fail "bench_blk start timeout" }
+    }
+    set timeout 300
+    expect {
+        "=== Done ===" { send_user "\n\[blk bench done\]\n" }
+        timeout { fail "bench_blk timeout" }
+    }
+    set timeout 600
+    expect {
+        "root@(none):/home/arm64# " {
+            send "echo '--- blk result (zone1) ---' && cat test/perfresult/bench_blk.txt 2>/dev/null || true\r"
+        }
+        timeout { fail "bench_blk result print timeout" }
+    }
+    expect {
+        "root@(none):/home/arm64# " {
+            send "\x01\x01d"
+        }
+        timeout { fail "zone1 screen detach timeout" }
+    }
+    expect {
+        "root@(none):/home/arm64# " {
+            send "./hvisor zone shutdown -id 1\r"
+        }
+        timeout { fail "zone1 shutdown timeout" }
+    }
+}
+
+send_user "\r============ hvisor Single Benchmark (aarch64/qemu-gicv3, ptest=$ptest) ============\r"
+
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly"
+    }
+}
+
+expect {
+    -re "(1 bootflow, 1 valid).*=>" {
+        send "bootm 0x40400000 - 0x40000000\r"
+    }
+    timeout { fail "U-Boot prompt timeout" }
+}
+
+expect {
+    -re {job control turned off.*#} {
+        send "bash\r"
+    }
+    timeout { fail "zone0 shell timeout" }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/arm64\r"
+    }
+    timeout { fail "zone0 cd /home/arm64 timeout" }
+}
+
+expect {
+    "root@(none):/home/arm64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "mkdir test/perfresult timeout" }
+}
+
+expect {
+    "root@(none):/home/arm64# " {
+        send "mount -t proc proc /proc 2>/dev/null || true; mount -t sysfs sysfs /sys 2>/dev/null || true; mkdir -p /dev/shm; mount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\r"
+    }
+    timeout { fail "prepare /proc /sys /dev/shm timeout" }
+}
+
+if {$ptest eq "mem"} {
+    run_bench "Memory" "./test/bench/bench_mem.sh" 600 "test/perfresult/bench_mem.txt"
+} elseif {$ptest eq "irq"} {
+    run_bench "IRQ" "./test/bench/bench_irq.sh" 180 "test/perfresult/bench_irq.txt"
+} elseif {$ptest eq "net"} {
+    run_bench "Network" "./test/bench/bench_net.sh" 180 "test/perfresult/bench_net.txt"
+} elseif {$ptest eq "blk"} {
+    run_blk_bench_in_zone1
+} else {
+    fail "unsupported PTEST=$ptest, use mem|irq|net|blk"
+}
+
+send_user "\n============ Single Benchmark Finished ============\n"
+set run_exited_unexpectedly 0
+send "\x01x"
+set timeout 20
+expect {
+    eof {}
+    timeout {}
+}
+catch {close}
+catch {wait}
+exit 0

--- a/platform/riscv64/qemu-plic/test/perftest/bench_blk.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/bench_blk.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+# Zone1 virtio-blk benchmark: fio preferred, dd fallback
+
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_blk.txt"
+
+echo "=== Virtio-BLK Benchmark (Zone1) ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+
+ROOT_DEV="$(findmnt -n -o SOURCE / 2>/dev/null || true)"
+if [ -n "$ROOT_DEV" ]; then
+    echo "[root device] $ROOT_DEV" | tee -a "$OUTFILE"
+fi
+
+echo "[writeback sync]" | tee -a "$OUTFILE"
+sync
+
+echo "" | tee -a "$OUTFILE"
+if command -v fio > /dev/null 2>&1; then
+    FIO_FILE="/home/riscv64/test/perfresult/fio_blk_bench.dat"
+    echo "[fio seq-write 128M -> ${FIO_FILE}]" | tee -a "$OUTFILE"
+    fio --name=blk-seq-write --rw=write --bs=1M --size=128M --numjobs=1 \
+        --filename="${FIO_FILE}" --direct=1 --ioengine=libaio --iodepth=16 \
+        --end_fsync=1 --output-format=normal 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+
+    echo "[fio seq-read 128M <- ${FIO_FILE}]" | tee -a "$OUTFILE"
+    fio --name=blk-seq-read --rw=read --bs=1M --size=128M --numjobs=1 \
+        --filename="${FIO_FILE}" --direct=1 --ioengine=libaio --iodepth=16 \
+        --output-format=normal 2>&1 | tee -a "$OUTFILE"
+    rm -f "${FIO_FILE}"
+else
+    BENCH_FILE="/home/riscv64/test/perfresult/hv_blk_bench.dd"
+    echo "[fio not found - fallback to dd]" | tee -a "$OUTFILE"
+    echo "[Write: dd if=/dev/zero of=${BENCH_FILE} bs=1M count=128 conv=fdatasync]" | tee -a "$OUTFILE"
+    dd if=/dev/zero of="${BENCH_FILE}" bs=1M count=128 conv=fdatasync 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+
+    echo "[Read: dd if=${BENCH_FILE} of=/dev/null bs=1M]" | tee -a "$OUTFILE"
+    dd if="${BENCH_FILE}" of=/dev/null bs=1M 2>&1 | tee -a "$OUTFILE"
+    rm -f "${BENCH_FILE}"
+fi
+
+echo "" | tee -a "$OUTFILE"
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/riscv64/qemu-plic/test/perftest/bench_irq.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/bench_irq.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Zone0 IRQ statistics and timer latency measurement
+# Uses cyclictest (rt-tests) when available; falls back to date-based sleep jitter
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_irq.txt"
+echo "=== IRQ / Timer Latency Benchmark ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+echo "[/proc/interrupts]" | tee -a "$OUTFILE"
+if [ -r /proc/interrupts ]; then
+    cat /proc/interrupts | tee -a "$OUTFILE"
+else
+    echo "/proc/interrupts unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+
+run_sleep_jitter() {
+    i=0
+    while [ $i -lt 20 ]; do
+        t1=$(date +%s%N 2>/dev/null)
+        sleep 0.01
+        t2=$(date +%s%N 2>/dev/null)
+        if echo "${t1}${t2}" | grep -qE '^[0-9]+$'; then
+            delta=$((t2 - t1))
+            echo "  sample $((i+1)): ${delta} ns  (expected ~10000000)" | tee -a "$OUTFILE"
+        else
+            echo "  sample $((i+1)): nanosecond timestamp unavailable" | tee -a "$OUTFILE"
+        fi
+        i=$((i+1))
+    done
+}
+
+if command -v cyclictest > /dev/null 2>&1; then
+    echo "[cyclictest -l 1000 -i 1000 -t 1 (interval=1ms, 1000 loops)]" | tee -a "$OUTFILE"
+    TMP_OUT=$(mktemp /tmp/hv_cyclictest.XXXXXX)
+    if cyclictest -l 1000 -i 1000 -t 1 >"$TMP_OUT" 2>&1; then
+        cat "$TMP_OUT" | tee -a "$OUTFILE"
+    else
+        cat "$TMP_OUT" | tee -a "$OUTFILE"
+        echo "[cyclictest failed — falling back to 10ms sleep jitter, 20 samples]" | tee -a "$OUTFILE"
+        run_sleep_jitter
+    fi
+    rm -f "$TMP_OUT"
+else
+    echo "[cyclictest not found — falling back to 10ms sleep jitter, 20 samples]" | tee -a "$OUTFILE"
+    run_sleep_jitter
+fi
+echo "" | tee -a "$OUTFILE"
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/riscv64/qemu-plic/test/perftest/bench_mem.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/bench_mem.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Zone0 memory benchmark: stress-ng + fio when available; dd fallback
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_mem.txt"
+echo "=== Memory Benchmark ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+if command -v stress-ng > /dev/null 2>&1; then
+    echo "[stress-ng --vm 1 --vm-bytes 64M --vm-method all --timeout 20s --metrics-brief]" | tee -a "$OUTFILE"
+    stress-ng --vm 1 --vm-bytes 64M --vm-method all --timeout 20s --metrics-brief 2>&1 | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+else
+    echo "[stress-ng not found — skipping memory stress]" | tee -a "$OUTFILE"
+    echo "" | tee -a "$OUTFILE"
+fi
+if command -v fio > /dev/null 2>&1; then
+    BENCH_DIR=/tmp
+    FIO_FILE="$BENCH_DIR/fio_mem_bench"
+    AVAIL_KIB=$(df -Pk "$BENCH_DIR" 2>/dev/null | awk 'NR==2{print $4}')
+    FIO_SIZE_MIB=128
+    if [ -n "$AVAIL_KIB" ] && [ "$AVAIL_KIB" -gt 0 ] 2>/dev/null; then
+        AVAIL_MIB=$((AVAIL_KIB / 1024))
+        if [ "$AVAIL_MIB" -gt 16 ]; then
+            FIO_SIZE_MIB=$((AVAIL_MIB * 7 / 10))
+            if [ "$FIO_SIZE_MIB" -gt 128 ]; then
+                FIO_SIZE_MIB=128
+            fi
+            if [ "$FIO_SIZE_MIB" -lt 16 ]; then
+                FIO_SIZE_MIB=16
+            fi
+        elif [ "$AVAIL_MIB" -ge 10 ]; then
+            FIO_SIZE_MIB=8
+        else
+            FIO_SIZE_MIB=0
+        fi
+    fi
+
+    rm -f "${FIO_FILE}"
+    if [ "$FIO_SIZE_MIB" -eq 0 ]; then
+        echo "[fio skipped: insufficient free space on $BENCH_DIR]" | tee -a "$OUTFILE"
+        echo "" | tee -a "$OUTFILE"
+    else
+        echo "[fio seq-write ${FIO_SIZE_MIB}M -> $BENCH_DIR]" | tee -a "$OUTFILE"
+        if fio --name=seq-write --rw=write --bs=1M --size="${FIO_SIZE_MIB}M" --numjobs=1 \
+            --filename="${FIO_FILE}" --end_fsync=1 --output-format=normal 2>&1 | tee -a "$OUTFILE"; then
+            echo "" | tee -a "$OUTFILE"
+            echo "[fio seq-read ${FIO_SIZE_MIB}M <- $BENCH_DIR]" | tee -a "$OUTFILE"
+            fio --name=seq-read --rw=read --bs=1M --size="${FIO_SIZE_MIB}M" --numjobs=1 \
+                --filename="${FIO_FILE}" --output-format=normal 2>&1 | tee -a "$OUTFILE"
+        else
+            echo "" | tee -a "$OUTFILE"
+            echo "[fio write failed — skipping seq-read]" | tee -a "$OUTFILE"
+        fi
+        rm -f "${FIO_FILE}"
+        echo "" | tee -a "$OUTFILE"
+    fi
+else
+    echo "[fio not found — falling back to dd]" | tee -a "$OUTFILE"
+    BENCH_DIR=/tmp
+    BENCH_FILE="$BENCH_DIR/hv_bench_mem"
+    AVAIL_KIB=$(df -Pk "$BENCH_DIR" 2>/dev/null | awk 'NR==2{print $4}')
+    DD_COUNT_MIB=64
+    if [ -n "$AVAIL_KIB" ] && [ "$AVAIL_KIB" -gt 0 ] 2>/dev/null; then
+        AVAIL_MIB=$((AVAIL_KIB / 1024))
+        if [ "$AVAIL_MIB" -gt 16 ]; then
+            DD_COUNT_MIB=$((AVAIL_MIB * 7 / 10))
+            if [ "$DD_COUNT_MIB" -gt 64 ]; then
+                DD_COUNT_MIB=64
+            fi
+            if [ "$DD_COUNT_MIB" -lt 8 ]; then
+                DD_COUNT_MIB=8
+            fi
+        elif [ "$AVAIL_MIB" -ge 10 ]; then
+            DD_COUNT_MIB=8
+        else
+            DD_COUNT_MIB=0
+        fi
+    fi
+
+    rm -f "$BENCH_FILE"
+    if [ "$DD_COUNT_MIB" -eq 0 ]; then
+        echo "[dd skipped: insufficient free space on $BENCH_DIR]" | tee -a "$OUTFILE"
+        echo "" | tee -a "$OUTFILE"
+    else
+        echo "[Write: dd if=/dev/zero of=$BENCH_FILE bs=1M count=$DD_COUNT_MIB conv=fdatasync]" | tee -a "$OUTFILE"
+        if dd if=/dev/zero of="$BENCH_FILE" bs=1M count="$DD_COUNT_MIB" conv=fdatasync 2>&1 | tee -a "$OUTFILE"; then
+            echo "" | tee -a "$OUTFILE"
+            echo "[Read: dd if=$BENCH_FILE of=/dev/null bs=1M]" | tee -a "$OUTFILE"
+            dd if="$BENCH_FILE" of=/dev/null bs=1M 2>&1 | tee -a "$OUTFILE"
+        else
+            echo "" | tee -a "$OUTFILE"
+            echo "[dd write failed — skipping read]" | tee -a "$OUTFILE"
+        fi
+        echo "" | tee -a "$OUTFILE"
+        rm -f "$BENCH_FILE"
+    fi
+fi
+echo "[/proc/meminfo]" | tee -a "$OUTFILE"
+if [ -r /proc/meminfo ]; then
+    cat /proc/meminfo | tee -a "$OUTFILE"
+else
+    echo "/proc/meminfo unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/riscv64/qemu-plic/test/perftest/bench_mem.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/bench_mem.sh
@@ -96,11 +96,6 @@ else
         rm -f "$BENCH_FILE"
     fi
 fi
-echo "[/proc/meminfo]" | tee -a "$OUTFILE"
-if [ -r /proc/meminfo ]; then
-    cat /proc/meminfo | tee -a "$OUTFILE"
-else
-    echo "/proc/meminfo unavailable" | tee -a "$OUTFILE"
-fi
+
 echo "" | tee -a "$OUTFILE"
 echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/riscv64/qemu-plic/test/perftest/bench_net.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/bench_net.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+# riscv64/qemu-plic has no virtio-net by default; ping will report failure gracefully.
+# iperf3 loopback test requires working lo interface.
+RESULT_DIR="./test/perfresult"
+mkdir -p "$RESULT_DIR"
+OUTFILE="$RESULT_DIR/bench_net.txt"
+GATEWAY="10.0.2.2"
+echo "=== Network Benchmark (zone0) ===" | tee "$OUTFILE"
+echo "Date: $(date)" | tee -a "$OUTFILE"
+echo "" | tee -a "$OUTFILE"
+echo "[/proc/net/dev]" | tee -a "$OUTFILE"
+if [ -r /proc/net/dev ]; then
+    cat /proc/net/dev | tee -a "$OUTFILE"
+else
+    echo "/proc/net/dev unavailable" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+echo "[ping ${GATEWAY} -c 50 -i 0.02]" | tee -a "$OUTFILE"
+PING_LOG=$(mktemp /tmp/hv_ping.XXXXXX)
+if ping -c 50 -i 0.02 "$GATEWAY" >"$PING_LOG" 2>&1; then
+    cat "$PING_LOG" | tee -a "$OUTFILE"
+    echo "ping completed" | tee -a "$OUTFILE"
+else
+    cat "$PING_LOG" | tee -a "$OUTFILE"
+    echo "ping failed or network not available" | tee -a "$OUTFILE"
+fi
+rm -f "$PING_LOG"
+echo "" | tee -a "$OUTFILE"
+
+echo "[loopback readiness]" | tee -a "$OUTFILE"
+if command -v ip > /dev/null 2>&1; then
+    ip link set lo up >/dev/null 2>&1 || true
+    echo "attempted: ip link set lo up" | tee -a "$OUTFILE"
+elif command -v ifconfig > /dev/null 2>&1; then
+    ifconfig lo up >/dev/null 2>&1 || true
+    echo "attempted: ifconfig lo up" | tee -a "$OUTFILE"
+else
+    echo "no ip/ifconfig command, cannot explicitly bring up lo" | tee -a "$OUTFILE"
+fi
+
+LO_LOG=$(mktemp /tmp/hv_lo_ping.XXXXXX)
+if ping -c 1 127.0.0.1 >"$LO_LOG" 2>&1; then
+    cat "$LO_LOG" | tee -a "$OUTFILE"
+    LO_READY=1
+else
+    cat "$LO_LOG" | tee -a "$OUTFILE"
+    LO_READY=0
+fi
+rm -f "$LO_LOG"
+echo "" | tee -a "$OUTFILE"
+
+if command -v iperf3 > /dev/null 2>&1; then
+    if [ "$LO_READY" -eq 1 ]; then
+        echo "[iperf3 loopback: server on 127.0.0.1:5201, duration 10s]" | tee -a "$OUTFILE"
+        IPERF_SRV_LOG=$(mktemp /tmp/hv_iperf3_srv.XXXXXX)
+        IPERF_CLI_LOG=$(mktemp /tmp/hv_iperf3_cli.XXXXXX)
+        iperf3 -s -p 5201 >"$IPERF_SRV_LOG" 2>&1 &
+        IPERF_PID=$!
+        sleep 1
+        if ! kill -0 "$IPERF_PID" 2>/dev/null; then
+            echo "iperf3 server start failed" | tee -a "$OUTFILE"
+            cat "$IPERF_SRV_LOG" | tee -a "$OUTFILE"
+        else
+            if iperf3 -c 127.0.0.1 -p 5201 -t 10 >"$IPERF_CLI_LOG" 2>&1; then
+                cat "$IPERF_CLI_LOG" | tee -a "$OUTFILE"
+                echo "iperf3 loopback completed" | tee -a "$OUTFILE"
+            else
+                cat "$IPERF_CLI_LOG" | tee -a "$OUTFILE"
+                echo "iperf3 client failed" | tee -a "$OUTFILE"
+            fi
+        fi
+        kill "$IPERF_PID" 2>/dev/null || true
+        wait "$IPERF_PID" 2>/dev/null || true
+        rm -f "$IPERF_SRV_LOG" "$IPERF_CLI_LOG"
+    else
+        echo "loopback not ready, skipping iperf3 loopback test" | tee -a "$OUTFILE"
+    fi
+else
+    echo "[iperf3 not found — skipping throughput test]" | tee -a "$OUTFILE"
+fi
+echo "" | tee -a "$OUTFILE"
+echo "=== Done ===" | tee -a "$OUTFILE"

--- a/platform/riscv64/qemu-plic/test/perftest/tdownload_all.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/tdownload_all.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# perftest wrapper for riscv64/qemu-plic
+# Calls systemtest/tdownload_all.sh then ensures rootfs2.ext4 is extracted.
+set -e
+
+WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+UNZIP_DIR="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/image/virtdisk"
+ROOTFS1="${UNZIP_DIR}/rootfs1.ext4"
+ROOTFS2="${UNZIP_DIR}/rootfs2.ext4"
+
+# Step 1: run the original download script (handles rootfs1.ext4 + Image)
+"${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/test/systemtest/tdownload_all.sh" || true
+# The systemtest script may exit non-zero if rootfs2 extraction fails; we handle that below.
+
+# Step 2: if rootfs2.ext4 is still missing, extract it from rootfs1.ext4 ourselves
+if [ ! -f "$ROOTFS2" ]; then
+    echo "[perftest/tdownload_all] rootfs2.ext4 not found, extracting from rootfs1.ext4 ..."
+
+    if [ ! -f "$ROOTFS1" ]; then
+        echo "ERROR: $ROOTFS1 does not exist" >&2
+        exit 1
+    fi
+
+    LOOP_MNT=$(mktemp -d /tmp/hvisor-rootfs1-mnt.XXXXXX)
+    sudo mount -o loop "$ROOTFS1" "$LOOP_MNT"
+
+    if [ ! -f "$LOOP_MNT/home/riscv64/riscv_rootfs2.img" ]; then
+        sudo umount "$LOOP_MNT"
+        rmdir "$LOOP_MNT"
+        echo "ERROR: riscv_rootfs2.img not found inside rootfs1.ext4" >&2
+        exit 1
+    fi
+
+    cp "$LOOP_MNT/home/riscv64/riscv_rootfs2.img" "$ROOTFS2"
+    sudo umount "$LOOP_MNT"
+    rmdir "$LOOP_MNT"
+    echo "[perftest/tdownload_all] rootfs2.ext4 extracted successfully."
+else
+    echo "[perftest/tdownload_all] rootfs2.ext4 already exists, skipping extraction."
+fi

--- a/platform/riscv64/qemu-plic/test/perftest/trootfs_deploy.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/trootfs_deploy.sh
@@ -158,11 +158,11 @@ ensure_tools_in_rootfs "${ROOTFS_MNT}"
 echo "=== Deploying zone0 perf bench scripts ==="
 BENCH_DEST="${ROOTFS_MNT}/home/riscv64/test/bench"
 sudo mkdir -p "${BENCH_DEST}"
-sudo cp -v "${PERF_DIR}"/bench_*.sh "${BENCH_DEST}/"
+sudo cp -v "${PERF_DIR}/bench_mem.sh" "${PERF_DIR}/bench_irq.sh" "${PERF_DIR}/bench_net.sh" "${BENCH_DEST}/"
 sudo chmod +x "${BENCH_DEST}"/bench_*.sh
 sudo mkdir -p "${ROOTFS_MNT}/home/riscv64/test/perfresult"
 
-echo "=== Bench scripts deployed ==="
+echo "=== rootfs1 perf scripts deployed ==="
 sudo find "${ROOTFS_MNT}/home/riscv64/test" -ls
 
 # Step 5: mount rootfs2 and deploy zone1 blk bench script + install tools

--- a/platform/riscv64/qemu-plic/test/perftest/trootfs_deploy.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/trootfs_deploy.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+set -e
+set -x
+
+WORKSPACE_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+PERF_DIR="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/test/perftest"
+ROOTFS_EXT4="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/image/virtdisk/rootfs1.ext4"
+ROOTFS_MNT="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/image/virtdisk/rootfs"
+ROOTFS2_EXT4="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/image/virtdisk/rootfs2.ext4"
+ROOTFS2_MNT="${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/image/virtdisk/rootfs2"
+ROOTFS2_IMAGE=""
+
+bench_tools=(fio rt-tests stress-ng iperf3 iproute2)
+
+# Cleanup: unmount bind mounts and rootfs on any exit (error or normal)
+cleanup() {
+    sudo umount "${ROOTFS_MNT}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/var/lib/apt/lists"      2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/sys"  2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/proc" 2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}/dev"  2>/dev/null || true
+    [ -f "${ROOTFS_MNT}/usr/bin/qemu-riscv64-static" ] && \
+        sudo rm -f "${ROOTFS_MNT}/usr/bin/qemu-riscv64-static" || true
+    sudo umount "${ROOTFS2_MNT}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/var/lib/apt/lists"      2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/sys"  2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/proc" 2>/dev/null || true
+    sudo umount "${ROOTFS2_MNT}/dev"  2>/dev/null || true
+    [ -f "${ROOTFS2_MNT}/usr/bin/qemu-riscv64-static" ] && \
+        sudo rm -f "${ROOTFS2_MNT}/usr/bin/qemu-riscv64-static" || true
+    sudo umount "${ROOTFS2_MNT}" 2>/dev/null || true
+    sudo umount "${ROOTFS_MNT}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Remove stale mounts before invoking systemtest deploy.
+cleanup
+
+resolve_rootfs2_image() {
+    if [ -f "${ROOTFS2_EXT4}" ]; then
+        ROOTFS2_IMAGE="${ROOTFS2_EXT4}"
+    elif [ -f "${ROOTFS_MNT}/home/riscv64/riscv_rootfs2.img" ]; then
+        ROOTFS2_IMAGE="${ROOTFS_MNT}/home/riscv64/riscv_rootfs2.img"
+    elif [ -f "${ROOTFS_MNT}/home/riscv64/rootfs2.ext4" ]; then
+        ROOTFS2_IMAGE="${ROOTFS_MNT}/home/riscv64/rootfs2.ext4"
+    elif [ -f "${ROOTFS_MNT}/rootfs2.ext4" ]; then
+        ROOTFS2_IMAGE="${ROOTFS_MNT}/rootfs2.ext4"
+    else
+        ROOTFS2_IMAGE=""
+    fi
+
+    if [ -n "${ROOTFS2_IMAGE}" ]; then
+        echo "=== rootfs2 image resolved: ${ROOTFS2_IMAGE} ==="
+    fi
+}
+
+# Expand an ext2/ext3/ext4 image file in-place if free space is below min_free_mb.
+# Must be called while the image is NOT mounted.
+expand_ext2_if_needed() {
+    local img="$1"
+    local min_free_mb="${2:-1024}"
+
+    local info block_size free_blocks free_mb
+    info=$(sudo dumpe2fs -h "${img}" 2>/dev/null) || {
+        echo "WARN: cannot read ${img}, skipping expand" >&2
+        return 0
+    }
+    block_size=$(echo "${info}" | awk '/^Block size:/{print $3}')
+    free_blocks=$(echo "${info}" | awk '/^Free blocks:/{gsub(/,/,"",$3); print $3}')
+    if [ -z "${block_size}" ] || [ -z "${free_blocks}" ]; then
+        echo "WARN: could not parse free space in ${img}, skipping expand" >&2
+        return 0
+    fi
+    free_mb=$(( (block_size * free_blocks) / 1024 / 1024 ))
+    echo "=== ${img}: ${free_mb}MB free (need ${min_free_mb}MB) ==="
+    if [ "${free_mb}" -ge "${min_free_mb}" ]; then
+        return 0
+    fi
+
+    local add_mb=$(( min_free_mb - free_mb + 128 ))
+    echo "=== Expanding ${img} by +${add_mb}MB ==="
+    sudo truncate --size=+${add_mb}M "${img}"
+    sudo e2fsck -f -y "${img}" || true
+    sudo resize2fs "${img}"
+    echo "=== Expansion done ==="
+}
+
+ensure_tools_in_rootfs() {
+    local mnt="$1"
+    local mode="${2:-strict}"
+
+    if [ -f "${mnt}/usr/bin/fio" ] && \
+       [ -f "${mnt}/usr/bin/cyclictest" ] && \
+       [ -f "${mnt}/usr/bin/stress-ng" ] && \
+       [ -f "${mnt}/usr/bin/iperf3" ]; then
+        echo "=== Benchmarking tools already installed in ${mnt}, skipping apt install ==="
+        return 0
+    fi
+
+    echo "=== Installing benchmarking tools in ${mnt} via chroot (mode=${mode}) ==="
+    local qemu_static="/usr/bin/qemu-riscv64-static"
+    local rc=0
+
+    # Use host tmpdirs for apt lists/cache to avoid filling guest image space.
+    local apt_lists_tmp apt_cache_tmp
+    apt_lists_tmp=$(mktemp -d)
+    apt_cache_tmp=$(mktemp -d)
+
+    if [ -f "${qemu_static}" ]; then
+        sudo cp "${qemu_static}" "${mnt}/usr/bin/qemu-riscv64-static"
+    fi
+    sudo mount --bind /dev  "${mnt}/dev"
+    sudo mount --bind /proc "${mnt}/proc"
+    sudo mount --bind /sys  "${mnt}/sys"
+    sudo mkdir -p "${mnt}/var/lib/apt/lists" "${mnt}/var/cache/apt/archives"
+    sudo mount --bind "${apt_lists_tmp}" "${mnt}/var/lib/apt/lists"
+    sudo mount --bind "${apt_cache_tmp}" "${mnt}/var/cache/apt/archives"
+
+    set +e
+    sudo chroot "${mnt}" sh -c \
+        "apt-get update && apt-get install -y --no-install-recommends ${bench_tools[*]}"
+    rc=$?
+    set -e
+
+    sudo umount "${mnt}/var/cache/apt/archives" 2>/dev/null || true
+    sudo umount "${mnt}/var/lib/apt/lists" 2>/dev/null || true
+    rm -rf "${apt_lists_tmp}" "${apt_cache_tmp}"
+    sudo umount "${mnt}/sys" 2>/dev/null || true
+    sudo umount "${mnt}/proc" 2>/dev/null || true
+    sudo umount "${mnt}/dev" 2>/dev/null || true
+    sudo rm -f "${mnt}/usr/bin/qemu-riscv64-static"
+
+    if [ $rc -ne 0 ]; then
+        if [ "${mode}" = "optional" ]; then
+            echo "WARN: apt install failed in ${mnt}, continue with existing tools / benchmark fallback." >&2
+            return 0
+        fi
+        echo "ERROR: apt install failed in ${mnt}" >&2
+        return $rc
+    fi
+
+    echo "=== chroot install done for ${mnt} ==="
+}
+
+# Step 1: run the original systemtest deploy (hvisor, hvisor.ko, dtb, json, test scripts)
+echo "=== Running base systemtest deploy ==="
+"${WORKSPACE_ROOT}/platform/riscv64/qemu-plic/test/systemtest/trootfs_deploy.sh"
+
+# Step 2: mount rootfs again and deploy bench scripts + install tools
+echo "=== Mounting rootfs ==="
+sudo mkdir -p "${ROOTFS_MNT}"
+sudo mount "${ROOTFS_EXT4}" "${ROOTFS_MNT}"
+
+# Step 3: install benchmarking tools for zone0/rootfs1.
+ensure_tools_in_rootfs "${ROOTFS_MNT}"
+
+# Step 4: deploy zone0 bench scripts into rootfs1
+echo "=== Deploying zone0 perf bench scripts ==="
+BENCH_DEST="${ROOTFS_MNT}/home/riscv64/test/bench"
+sudo mkdir -p "${BENCH_DEST}"
+sudo cp -v "${PERF_DIR}"/bench_*.sh "${BENCH_DEST}/"
+sudo chmod +x "${BENCH_DEST}"/bench_*.sh
+sudo mkdir -p "${ROOTFS_MNT}/home/riscv64/test/perfresult"
+
+echo "=== Bench scripts deployed ==="
+sudo find "${ROOTFS_MNT}/home/riscv64/test" -ls
+
+# Step 5: mount rootfs2 and deploy zone1 blk bench script + install tools
+resolve_rootfs2_image
+if [ -n "${ROOTFS2_IMAGE}" ]; then
+    expand_ext2_if_needed "${ROOTFS2_IMAGE}"
+    echo "=== Mounting rootfs2 (${ROOTFS2_IMAGE}) ==="
+    sudo mkdir -p "${ROOTFS2_MNT}"
+    sudo mount "${ROOTFS2_IMAGE}" "${ROOTFS2_MNT}"
+
+    # Install benchmarking tools in rootfs2 (optional, may fail for small images)
+    ensure_tools_in_rootfs "${ROOTFS2_MNT}" optional
+
+    # Deploy zone1 blk bench script
+    echo "=== Deploying zone1 blk perf script to rootfs2 ==="
+    sudo mkdir -p "${ROOTFS2_MNT}/home/riscv64/test/bench"
+    sudo mkdir -p "${ROOTFS2_MNT}/home/riscv64/test/perfresult"
+    sudo cp -v "${PERF_DIR}/bench_blk.sh" "${ROOTFS2_MNT}/home/riscv64/test/bench/"
+    sudo chmod +x "${ROOTFS2_MNT}/home/riscv64/test/bench/bench_blk.sh"
+    sudo find "${ROOTFS2_MNT}/home/riscv64/test" -ls
+
+    sudo umount "${ROOTFS2_MNT}"
+else
+    echo "WARN: rootfs2 image not found, skipping zone1 blk bench deployment"
+fi
+
+sudo umount "${ROOTFS_MNT}"
+
+trap - EXIT
+echo "=== perftest rootfs deploy done ==="

--- a/platform/riscv64/qemu-plic/test/perftest/tstart.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/tstart.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/expect -f
+
+# riscv64/qemu-plic performance benchmark driver
+# Runs zone0 mem/irq/net benchmarks (net may be unavailable), then zone1 startup timing.
+# Data collection only (no benchmark pass/fail assertion); exits non-zero on infra/timeout failures.
+
+set env(LANG) "en_US.UTF-8"
+send_user "\r============ hvisor Performance Benchmark (riscv64/qemu-plic) ============\r"
+set run_exited_unexpectedly 1
+
+set qemu_match "qemu-system-riscv64.*platform/riscv64/qemu-plic/image/virtdisk/rootfs1.ext4"
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+# Clear stale QEMU from previous interrupted runs to avoid image lock.
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly (likely QEMU start failure or image lock)"
+    }
+}
+
+# ── Stage 1: Wait for zone1 pty allocation, then enter QEMU monitor ──
+expect {
+    -re "char device redirected to /dev/pts.*(label X10007000)" {
+        send "\x01c"
+    }
+    timeout {
+        fail "pty redirect timeout"
+    }
+}
+
+expect {
+    "(qemu)" {
+        send "c\r"
+    }
+    timeout {
+        fail "QEMU monitor timeout"
+    }
+}
+
+# ── Stage 2: Zone0 shell ──
+expect {
+    -re {job control turned off.*#} {
+        send "\x01cbash\r"
+    }
+    timeout {
+        fail "zone0 shell timeout"
+    }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/riscv64\r"
+    }
+    timeout { fail "zone0 cd /home/riscv64 timeout" }
+}
+
+expect {
+    "root@(none):/home/riscv64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "mkdir test/perfresult timeout" }
+}
+
+expect {
+    "root@(none):/home/riscv64# " {
+        send "mount -t proc proc /proc 2>/dev/null || true; mount -t sysfs sysfs /sys 2>/dev/null || true; mkdir -p /dev/shm; mount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\r"
+    }
+    timeout { fail "prepare /proc /sys /dev/shm timeout" }
+}
+
+# ── Stage 3: Zone0 memory benchmark ──
+send_user "\n\n============ Zone0: Memory Benchmark ============\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./test/bench/bench_mem.sh\r"
+    }
+    timeout { fail "bench_mem start timeout" }
+}
+set timeout 600
+expect {
+    "=== Done ===" { send_user "\n\[mem bench done\]\n" }
+    "root@(none):/home/riscv64# " { fail "bench_mem exited without done marker" }
+    timeout {
+        fail "bench_mem timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 4: Zone0 IRQ / timer latency benchmark ──
+send_user "\n\n============ Zone0: IRQ / Timer Latency Benchmark ============\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./test/bench/bench_irq.sh\r"
+    }
+    timeout { fail "bench_irq start timeout" }
+}
+set timeout 120
+expect {
+    "=== Done ===" { send_user "\n\[irq bench done\]\n" }
+    timeout {
+        fail "bench_irq timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 5: Zone0 network benchmark (may report no network for riscv64) ──
+send_user "\n\n============ Zone0: Network Benchmark ============\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./test/bench/bench_net.sh\r"
+    }
+    timeout { fail "bench_net start timeout" }
+}
+set timeout 120
+expect {
+    "=== Done ===" { send_user "\n\[net bench done\]\n" }
+    timeout {
+        fail "bench_net timeout"
+    }
+}
+set timeout 600
+
+# ── Stage 6: Load hvisor kernel module ──
+send_user "\n\n============ Loading hvisor.ko ============\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "insmod hvisor.ko\r"
+    }
+    timeout { fail "insmod hvisor.ko timeout" }
+}
+
+# ── Stage 7: Start zone1 and measure startup time ──
+send_user "\n\n============ Zone1: Startup Time Measurement ============\n"
+set zone1_start [clock milliseconds]
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./boot_zone1.sh\r"
+    }
+    timeout { fail "boot_zone1 start timeout" }
+}
+expect {
+    -re {Script started.*#} {
+        send "bash\r"
+    }
+    timeout {
+        fail "zone1 boot timeout"
+    }
+}
+set zone1_end [clock milliseconds]
+set zone1_startup_ms [expr {$zone1_end - $zone1_start}]
+send_user "\nzone1 startup time: ${zone1_startup_ms} ms\n"
+
+# ── Stage 8: Detach from zone1 ──
+# Shutting down zone1
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./hvisor zone shutdown -id 1\r"
+    }
+    timeout {
+        fail "zone1 shutdown timeout"
+    }
+}
+
+# ── Stage 9: Print summary ──
+send_user "\n\n============ Benchmark Summary ============\n"
+send_user "Zone1 startup time: ${zone1_startup_ms} ms\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "echo '--- perf results ---' && cat test/perfresult/*.txt 2>/dev/null || echo '(no result files in zone0 perfresult)'\r"
+        send_user "\n============ hvisor Performance Benchmark Finished ============\n"
+        set run_exited_unexpectedly 0
+        send "\x01x"
+        set timeout 20
+        expect {
+            eof {}
+            timeout {}
+        }
+        catch {close}
+        catch {wait}
+        exit 0
+    }
+    timeout { fail "print benchmark summary timeout" }
+}

--- a/platform/riscv64/qemu-plic/test/perftest/tstart_blk.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/tstart_blk.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/expect -f
+
+# riscv64/qemu-plic standalone virtio-blk benchmark driver (zone1)
+# Runs zone1 startup + screen enter + bench_blk + shutdown.
+
+set env(LANG) "en_US.UTF-8"
+send_user "\r============ hvisor Virtio-BLK Benchmark (riscv64/qemu-plic) ============\r"
+set run_exited_unexpectedly 1
+
+set qemu_match "qemu-system-riscv64.*platform/riscv64/qemu-plic/image/virtdisk/rootfs1.ext4"
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+# Clear stale QEMU from previous interrupted runs to avoid image lock.
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly (likely QEMU start failure or image lock)"
+    }
+}
+
+expect {
+    -re "char device redirected to /dev/pts.*(label X10007000)" {
+        send "\x01c"
+    }
+    timeout { fail "pty redirect timeout" }
+}
+
+expect {
+    "(qemu)" {
+        send "c\r"
+    }
+    timeout { fail "QEMU monitor timeout" }
+}
+
+expect {
+    -re {job control turned off.*#} {
+        send "\x01cbash\r"
+    }
+    timeout { fail "zone0 shell timeout" }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/riscv64\r"
+    }
+    timeout { fail "zone0 cd /home/riscv64 timeout" }
+}
+
+expect {
+    "root@(none):/home/riscv64# " {
+        send "insmod hvisor.ko\r"
+    }
+    timeout { fail "insmod hvisor.ko timeout" }
+}
+
+send_user "\n\n============ Zone1: Startup Time Measurement ============\n"
+set zone1_start [clock milliseconds]
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./boot_zone1.sh\r"
+    }
+    timeout { fail "boot_zone1 start timeout" }
+}
+expect {
+    -re {Script started.*#} {
+        send "bash\r"
+    }
+    timeout { fail "zone1 boot timeout" }
+}
+set zone1_end [clock milliseconds]
+set zone1_startup_ms [expr {$zone1_end - $zone1_start}]
+send_user "\nzone1 startup time: ${zone1_startup_ms} ms\n"
+
+send_user "\n\n============ Zone1: Virtio-BLK Benchmark ============\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./screen_zone1.sh\r"
+        send "\r"
+    }
+    timeout { fail "screen_zone1 start timeout" }
+}
+expect {
+    -re {\r?\n# } {
+        send "bash\r"
+    }
+    timeout { fail "zone1 shell timeout" }
+}
+expect {
+    "root@(none):/# " {
+        send "cd /home/riscv64\r"
+    }
+    timeout { fail "zone1 cd /home/riscv64 timeout" }
+}
+expect {
+    "root@(none):/home/riscv64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "zone1 mkdir test/perfresult timeout" }
+}
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./test/bench/bench_blk.sh\r"
+    }
+    timeout { fail "bench_blk start timeout" }
+}
+set timeout 300
+expect {
+    "=== Done ===" { send_user "\n\[blk bench done\]\n" }
+    timeout { fail "bench_blk timeout" }
+}
+set timeout 600
+expect {
+    "root@(none):/home/riscv64# " {
+        send "echo '--- blk result (zone1) ---' && cat test/perfresult/bench_blk.txt 2>/dev/null || true\r"
+    }
+    timeout { fail "bench_blk result print timeout" }
+}
+expect {
+    "root@(none):/home/riscv64# " {
+        send "\x01\x01d"
+    }
+    timeout { fail "zone1 screen detach timeout" }
+}
+expect {
+    "root@(none):/home/riscv64# " {
+        send "./hvisor zone shutdown -id 1\r"
+    }
+    timeout { fail "zone1 shutdown timeout" }
+}
+
+send_user "\n\n============ Virtio-BLK Benchmark Summary ============\n"
+send_user "Zone1 startup time: ${zone1_startup_ms} ms\n"
+expect {
+    "root@(none):/home/riscv64# " {
+        send_user "\n============ hvisor Virtio-BLK Benchmark Finished ============\n"
+        set run_exited_unexpectedly 0
+        send "\x01x"
+        set timeout 20
+        expect {
+            eof {}
+            timeout {}
+        }
+        catch {close}
+        catch {wait}
+        exit 0
+    }
+    timeout { fail "final summary timeout" }
+}

--- a/platform/riscv64/qemu-plic/test/perftest/tstart_one.sh
+++ b/platform/riscv64/qemu-plic/test/perftest/tstart_one.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/expect -f
+
+# riscv64/qemu-plic single benchmark driver
+# Usage: PTEST=mem|irq|net|blk expect -f tstart_one.sh
+
+set env(LANG) "en_US.UTF-8"
+set run_exited_unexpectedly 1
+set qemu_match "qemu-system-riscv64.*platform/riscv64/qemu-plic/image/virtdisk/rootfs1.ext4"
+
+set ptest ""
+if {[info exists env(PTEST)]} {
+    set ptest $env(PTEST)
+}
+if {$ptest eq ""} {
+    send_user "ERROR: PTEST is empty, use mem|irq|net|blk\n"
+    exit 1
+}
+
+proc fail {msg} {
+    global qemu_match
+    send_user "\nERROR: $msg\n"
+    catch {send "\x01x"}
+    catch {close}
+    catch {wait}
+    catch {exec pkill -TERM -f -- $qemu_match}
+    catch {exec pkill -KILL -f -- $qemu_match}
+    exit 1
+}
+
+proc run_bench {name cmd timeout_sec result_file} {
+    send_user "\n\n============ Zone0: $name Benchmark ============\n"
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "$cmd\r"
+        }
+        timeout { fail "$name start timeout" }
+    }
+    set timeout $timeout_sec
+    expect {
+        "=== Done ===" { send_user "\n\[$name bench done\]\n" }
+        "root@(none):/home/riscv64# " { fail "$name exited without done marker" }
+        timeout { fail "$name timeout" }
+    }
+    set timeout 600
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "echo '--- $name result ---' && cat $result_file 2>/dev/null || true\r"
+        }
+        timeout { fail "$name result print timeout" }
+    }
+}
+
+proc run_blk_bench_in_zone1 {} {
+    send_user "\n\n============ Zone1: Virtio-BLK Benchmark ============\n"
+
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "insmod hvisor.ko\r"
+        }
+        timeout { fail "insmod hvisor.ko timeout" }
+    }
+
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "./boot_zone1.sh\r"
+        }
+        timeout { fail "boot_zone1 start timeout" }
+    }
+    expect {
+        -re {Script started.*#} {
+            send "bash\r"
+        }
+        timeout { fail "zone1 boot timeout" }
+    }
+
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "./screen_zone1.sh\r"
+            send "\r"
+        }
+        timeout { fail "screen_zone1 start timeout" }
+    }
+    expect {
+        -re {\r?\n# } {
+            send "bash\r"
+        }
+        timeout { fail "zone1 shell timeout" }
+    }
+    expect {
+        "root@(none):/# " {
+            send "cd /home/riscv64\r"
+        }
+        timeout { fail "zone1 cd /home/riscv64 timeout" }
+    }
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "mkdir -p test/perfresult\r"
+        }
+        timeout { fail "zone1 mkdir test/perfresult timeout" }
+    }
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "./test/bench/bench_blk.sh\r"
+        }
+        timeout { fail "bench_blk start timeout" }
+    }
+    set timeout 300
+    expect {
+        "=== Done ===" { send_user "\n\[blk bench done\]\n" }
+        timeout { fail "bench_blk timeout" }
+    }
+    set timeout 600
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "echo '--- blk result (zone1) ---' && cat test/perfresult/bench_blk.txt 2>/dev/null || true\r"
+        }
+        timeout { fail "bench_blk result print timeout" }
+    }
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "\x01\x01d"
+        }
+        timeout { fail "zone1 screen detach timeout" }
+    }
+    expect {
+        "root@(none):/home/riscv64# " {
+            send "./hvisor zone shutdown -id 1\r"
+        }
+        timeout { fail "zone1 shutdown timeout" }
+    }
+}
+
+send_user "\r============ hvisor Single Benchmark (riscv64/qemu-plic, ptest=$ptest) ============\r"
+
+catch {exec pkill -TERM -f -- $qemu_match}
+after 300
+spawn make run
+
+set timeout 600
+expect_before eof {
+    if {$run_exited_unexpectedly} {
+        fail "make run exited unexpectedly"
+    }
+}
+
+expect {
+    -re "char device redirected to /dev/pts.*(label X10007000)" {
+        send "\x01c"
+    }
+    timeout { fail "pty redirect timeout" }
+}
+
+expect {
+    "(qemu)" {
+        send "c\r"
+    }
+    timeout { fail "QEMU monitor timeout" }
+}
+
+expect {
+    -re {job control turned off.*#} {
+        send "\x01cbash\r"
+    }
+    timeout { fail "zone0 shell timeout" }
+}
+
+expect {
+    "root@(none):/# " {
+        send "cd /home/riscv64\r"
+    }
+    timeout { fail "zone0 cd /home/riscv64 timeout" }
+}
+
+expect {
+    "root@(none):/home/riscv64# " {
+        send "mkdir -p test/perfresult\r"
+    }
+    timeout { fail "mkdir test/perfresult timeout" }
+}
+
+expect {
+    "root@(none):/home/riscv64# " {
+        send "mount -t proc proc /proc 2>/dev/null || true; mount -t sysfs sysfs /sys 2>/dev/null || true; mkdir -p /dev/shm; mount -t tmpfs tmpfs /dev/shm 2>/dev/null || true\r"
+    }
+    timeout { fail "prepare /proc /sys /dev/shm timeout" }
+}
+
+if {$ptest eq "mem"} {
+    run_bench "Memory" "./test/bench/bench_mem.sh" 600 "test/perfresult/bench_mem.txt"
+} elseif {$ptest eq "irq"} {
+    run_bench "IRQ" "./test/bench/bench_irq.sh" 180 "test/perfresult/bench_irq.txt"
+} elseif {$ptest eq "net"} {
+    run_bench "Network" "./test/bench/bench_net.sh" 180 "test/perfresult/bench_net.txt"
+} elseif {$ptest eq "blk"} {
+    run_blk_bench_in_zone1
+} else {
+    fail "unsupported PTEST=$ptest, use mem|irq|net|blk"
+}
+
+send_user "\n============ Single Benchmark Finished ============\n"
+set run_exited_unexpectedly 0
+send "\x01x"
+set timeout 20
+expect {
+    eof {}
+    timeout {}
+}
+catch {close}
+catch {wait}
+exit 0


### PR DESCRIPTION
This PR enhances the testing and benchmarking infrastructure by
introducing additional tools, improving scripts, and extending test coverage.

### Benchmark Improvements
- Add support for downloading and using `fio`, `stress-ng`, `cyclictest`, and `iperf`
- Update bench_*.sh scripts to use the new tools
- Add cleanup handling on abnormal exits
- Fix disk space issue on rootfs2 by extending size

### Test Enhancements
- Add `perf` for whole test
- Add `ptest` for targeted testing scenarios
- Add virtio-blk tests for zone1

### Misc
- Introduce `perf-prepare-img` command to simplify performance testing setup

These changes improve reliability, coverage, and usability of the testing framework,
especially on qemu platform.