### PR TITLE
Fix linear map merge bug and data abort when start zone0 on rk3588

### DIFF
--- a/platform/aarch64/rk3588/board.rs
+++ b/platform/aarch64/rk3588/board.rs
@@ -57,7 +57,11 @@ pub const BOARD_PHYSMEM_LIST: &[(u64, u64, MemoryType)] = &[
  // (       start,           end,                type)
     (         0x0,    0xf0000000,  MemoryType::Normal),
     (  0xf0000000,   0x100000000,  MemoryType::Device),
-    ( 0x100000000,   0x3fc000000,  MemoryType::Normal)
+    ( 0x100000000,   0x3fc000000,  MemoryType::Normal),
+    // BOARD_PHYSMEM_LIST is the EL2 linear map and must stay 2 MiB aligned.
+    // Cover the root zone RAM at 0x3fc500000..0x3ffefffff with an aligned superset.
+    ( 0x3fc400000,   0x400000000,  MemoryType::Normal),
+    ( 0x4f0000000,   0x500000000,  MemoryType::Normal),
 ];
 
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x10000000;

--- a/src/arch/aarch64/mmu.rs
+++ b/src/arch/aarch64/mmu.rs
@@ -236,7 +236,7 @@ fn map_list(list: &[(u64, u64, MemoryType)]) {
     while i < list.len() {
         let (start, mut end, mem_type) = list[i];
         while i + 1 < list.len() && list[i + 1].0 == end && list[i + 1].2 == mem_type {
-            end = list[i].1;
+            end = list[i + 1].1;
             i += 1;
         }
         // map from start to end with mem_type


### PR DESCRIPTION
Close #288 

### Fix range coalescing in the MMU mapper

- When merging adjacent ranges of the same `MemoryType`, update `end` with
  `list[i + 1].1` (the next range end).

### Extend rk3588 EL2 linear-map physical ranges

- Add 2 MiB-aligned Normal-memory ranges in `BOARD_PHYSMEM_LIST` to cover
  root-zone high RAM, including an aligned superset for
  `0x3fc500000..0x3ffefffff`, plus one additional high Normal-memory segment.

## Impact

- Fixes incorrect merged end boundaries.
- Improves rk3588 EL2 mapping coverage for high RAM and reduces risk of
  translation faults in that region.
- Scope is minimal: MMU range merge logic + board-level memory map entries.