### PR TITLE
fix(PCIe): extend config space to 4KB and fix bus number enumeration for no_pcie_bar_realloc

### DIFF
--- a/src/pci/pci_config.rs
+++ b/src/pci/pci_config.rs
@@ -367,7 +367,7 @@ impl Zone {
                         }
                     }
                 } else {
-                    // warn!("can not find dev {:#?}", bdf);
+                    warn!("can not find dev {:#?} in GLOBAL_PCIE_LIST (not detected during enumeration)", bdf);
                     #[cfg(feature = "ecam_pcie")]
                     {
                         let dev_type = dev_config.dev_type;

--- a/src/pci/pci_struct.rs
+++ b/src/pci/pci_struct.rs
@@ -1337,9 +1337,24 @@ impl<B: BarAllocator> Iterator for PciIterator<B> {
                                 "bridge {:#?}: firmware secondary_bus={:#x}, subordinate_bus={:#x}",
                                 node.bdf, fw_secondary, fw_subordinate
                             );
-                            if fw_secondary != 0 {
+                            // Validate firmware bus number against configured range.
+                            // While the zone config maker is primarily responsible for
+                            // providing a valid range, this guard prevents invalid ECAM
+                            // accesses if firmware programs an out-of-range value.
+                            let range_start = self.bus_range.start as u8;
+                            let range_end = self.bus_range.end as u8;
+                            if fw_secondary != 0
+                                && fw_secondary >= range_start
+                                && fw_secondary <= range_end
+                            {
                                 fw_secondary
                             } else {
+                                if fw_secondary != 0 {
+                                    warn!(
+                                        "bridge {:#?}: firmware secondary_bus {:#x} out of range [{:#x}, {:#x}], falling back to calculated",
+                                        node.bdf, fw_secondary, range_start, range_end
+                                    );
+                                }
                                 parent.subordinate_bus + 1
                             }
                         };
@@ -1347,8 +1362,14 @@ impl<B: BarAllocator> Iterator for PciIterator<B> {
                         let next_bus = parent.subordinate_bus + 1;
 
                         let bdf = Bdf::new(domain, next_bus, 0, 0);
+                        // Use the current bridge's own bus as the immediate parent bus for
+                        // CFG address computation. For multi-level bridges (especially on
+                        // DWC), using parent.primary_bus (the upstream of the *parent*)
+                        // would select the wrong CFG0/CFG1 path and fail to reach devices
+                        // behind deeper bridges.
+                        let immediate_parent_bus = parent.bus;
                         Some(self.get_bridge().next_bridge(
-                            self.address(parent_bus, bdf),
+                            self.address(immediate_parent_bus, bdf),
                             node.has_secondary_link(),
                             self.is_mulitple_function,
                             self.function,

--- a/src/pci/pci_struct.rs
+++ b/src/pci/pci_struct.rs
@@ -143,7 +143,7 @@ impl ConfigValue {
 const MAX_DEVICE: u8 = 31;
 const MAX_FUNCTION: u8 = 7;
 pub const CONFIG_LENTH: u64 = 256;
-pub const BIT_LENTH: usize = 128 * 8;
+pub const BIT_LENTH: usize = 512 * 8; // 4096 bytes = full PCIe extended config space
 
 // PCIe Device/Port Type values
 const PCI_EXP_TYPE_ROOT_PORT: u16 = 4;
@@ -1318,12 +1318,41 @@ impl<B: BarAllocator> Iterator for PciIterator<B> {
                 self.next(match node.config_value.get_class().0 {
                     // class code 0x6 is bridge and class.1 0x0 is host bridge
                     0x6 if node.config_value.get_class().1 == 0x4 => {
-                        let bdf = Bdf::new(domain, parent.subordinate_bus + 1, 0, 0);
+                        // When no_pcie_bar_realloc is enabled, use the firmware-programmed
+                        // secondary bus number instead of calculating our own. Firmware
+                        // (UEFI/BIOS) may skip bus numbers for subordinate bus reservation,
+                        // causing calculated bus numbers to diverge from actual hardware
+                        // bus assignments — making devices behind bridges invisible.
+                        #[cfg(feature = "no_pcie_bar_realloc")]
+                        let next_bus = {
+                            let bridge_base = node.get_base();
+                            let bus_reg = unsafe {
+                                let ptr = PciConfigMmio::new(bridge_base, CONFIG_LENTH)
+                                    .access::<u32>(0x18);
+                                ptr.read_volatile()
+                            };
+                            let fw_secondary = ((bus_reg >> 8) & 0xFF) as u8;
+                            let fw_subordinate = ((bus_reg >> 16) & 0xFF) as u8;
+                            info!(
+                                "bridge {:#?}: firmware secondary_bus={:#x}, subordinate_bus={:#x}",
+                                node.bdf, fw_secondary, fw_subordinate
+                            );
+                            if fw_secondary != 0 {
+                                fw_secondary
+                            } else {
+                                parent.subordinate_bus + 1
+                            }
+                        };
+                        #[cfg(not(feature = "no_pcie_bar_realloc"))]
+                        let next_bus = parent.subordinate_bus + 1;
+
+                        let bdf = Bdf::new(domain, next_bus, 0, 0);
                         Some(self.get_bridge().next_bridge(
                             self.address(parent_bus, bdf),
                             node.has_secondary_link(),
                             self.is_mulitple_function,
                             self.function,
+                            next_bus,
                         ))
                     }
                     _ => None,
@@ -1392,14 +1421,15 @@ impl Bridge {
         has_secondary_link: bool,
         is_mulitple_function: bool,
         function: u8,
+        target_bus: u8,
     ) -> Self {
         let mmio = PciConfigMmio::new(address, CONFIG_LENTH);
         Self {
-            bus: self.subordinate_bus + 1,
+            bus: target_bus,
             device: 0,
             function,
-            subordinate_bus: self.subordinate_bus + 1,
-            secondary_bus: self.subordinate_bus + 1,
+            subordinate_bus: target_bus,
+            secondary_bus: target_bus,
             primary_bus: self.bus,
             mmio,
             has_secondary_link,
@@ -1412,14 +1442,22 @@ impl Bridge {
         if self.mmio.is_placeholder() {
             return;
         }
-        // we need to update the bridge bus number if we want linux not to update bus number
-        unsafe {
-            let ptr = self.mmio.access::<u32>(0x18);
-            let mut value = ptr.read_volatile();
-            value.set_bits(16..24, self.subordinate_bus.into());
-            value.set_bits(8..16, self.secondary_bus.into());
-            value.set_bits(0..8, self.primary_bus.into());
-            ptr.write_volatile(value);
+        // When no_pcie_bar_realloc is enabled, firmware already assigned correct bus
+        // numbers — don't overwrite them.
+        #[cfg(feature = "no_pcie_bar_realloc")]
+        return;
+
+        #[cfg(not(feature = "no_pcie_bar_realloc"))]
+        {
+            // we need to update the bridge bus number if we want linux not to update bus number
+            unsafe {
+                let ptr = self.mmio.access::<u32>(0x18);
+                let mut value = ptr.read_volatile();
+                value.set_bits(16..24, self.subordinate_bus.into());
+                value.set_bits(8..16, self.secondary_bus.into());
+                value.set_bits(0..8, self.primary_bus.into());
+                ptr.write_volatile(value);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Increase `BIT_LENTH` from 1024 to 4096 to support full PCIe extended configuration space (0x000-0xFFF). Eliminates `invalid pci offset 0x400+` warnings for devices with extended capabilities beyond 0x400.
- When `no_pcie_bar_realloc` is enabled, read firmware-programmed secondary bus numbers from bridge config space instead of calculating sequential ones. Fixes devices behind PCIe bridges becoming invisible when firmware bus assignments are non-sequential.

Closes #290

**Note on #214**: The `BIT_LENTH` fix does NOT resolve the SATA NCQ timeout reported in #214. That issue has a different root cause still under investigation. This PR only addresses the config space truncation (correctness improvement) and the bus number enumeration bug (confirmed fix for NVMe detection).

## Changes

### `src/pci/pci_struct.rs`
- `BIT_LENTH`: `128 * 8` (1024) → `512 * 8` (4096)
- `Iterator::next()` for `PciIterator`: under `no_pcie_bar_realloc`, reads bridge secondary_bus from config space offset 0x18 instead of `subordinate_bus + 1`
- `Bridge::next_bridge()`: accepts explicit `target_bus` parameter
- `Bridge::update_bridge_bus()`: no-op under `no_pcie_bar_realloc` to preserve firmware bus assignments

### `src/pci/pci_config.rs`
- Enable warning log when a device from zone config is not found in `GLOBAL_PCIE_LIST`

## Test plan

- [x] LoongArch 3A6000 + LS7A2000: NVMe (Realtek RTS5765DL at 0a:00.0) detected, mounted, and stable under sustained `dd` I/O
- [x] `invalid pci offset` warnings eliminated
- [ ] SATA heavy I/O stability — **NOT fixed by this PR**, root cause under separate investigation
- [ ] Verify no regression on other architectures (aarch64, riscv64)