### PR TITLE
riscv64: support msi irq-remapping for qemu-aia

### DIFF
--- a/.github/actions/setup-qemu/action.yml
+++ b/.github/actions/setup-qemu/action.yml
@@ -4,7 +4,7 @@ inputs:
   qemu-version:
     description: 'QEMU version to install'
     required: false
-    default: '9.0.2'
+    default: '10.1.0'
   install-path:
     description: 'Custom installation path'
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,20 @@ jobs:
         with:
           targets: ${{ matrix.rustc_target }}
           components: rust-src
+      - name: Setup QEMU from Source
+        if: matrix.arch == 'riscv64'
+        uses: ./.github/actions/setup-qemu
+        with:
+          qemu-version: "10.1.0"
+          install-path: "/opt/qemu"
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-system-aarch64 qemu-system-riscv64 gdb-multiarch llvm-dev libclang-dev wget
+          if [ "${{ matrix.arch }}" = "riscv64" ]; then
+            sudo apt-get install -y gdb-multiarch llvm-dev libclang-dev wget
+          else
+            sudo apt-get install -y qemu-system-aarch64 gdb-multiarch llvm-dev libclang-dev wget
+          fi
           cargo install --version 0.3.0 --locked cargo-binutils
       - name: Set up environment variables
         run: |

--- a/platform/riscv64/qemu-aia/README.md
+++ b/platform/riscv64/qemu-aia/README.md
@@ -6,3 +6,5 @@ If you are unfamiliar with the usage of hvisor config and hvisor-riscv, please r
 For content not specified in board.rs, please refer to the comments in `platform/riscv64/qemu-plic/board.rs` and `platform/riscv64/README.md`.
 
 Especially the explanation regarding HW_IRQS.
+
+For current code, please confirm the zonex's IMSIC_S_BASE is the same as the global IMSIC_S_BASE.

--- a/platform/riscv64/qemu-aia/board.rs
+++ b/platform/riscv64/qemu-aia/board.rs
@@ -41,7 +41,6 @@ pub const IMSIC_NUM_IDS: usize = 0xFF;
 pub const IOMMU_SYS_BASE: usize = 0x3010000;
 pub const IOMMU_SYS_SIZE: usize = 0x1000;
 
-
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x8f000000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x90000000;
 pub const ROOT_ZONE_ENTRY: u64 = 0x90000000;
@@ -65,8 +64,7 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
 
 pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 0x20;
 pub const HW_IRQS: &[u32] = &[7, 10, 33, 34];
-pub const ROOT_ZONE_IRQS_BITMAP: &[BitmapWord] =
-    &get_irqs_bitmap(&[10, 33]); // ARCH= riscv .It doesn't matter temporarily.
+pub const ROOT_ZONE_IRQS_BITMAP: &[BitmapWord] = &get_irqs_bitmap(&[10, 33]); // ARCH= riscv .It doesn't matter temporarily.
 
 pub const ROOT_ARCH_ZONE_CONFIG: HvArchZoneConfig = HvArchZoneConfig {
     plic_base: 0x0,

--- a/platform/riscv64/qemu-aia/cargo/features
+++ b/platform/riscv64/qemu-aia/cargo/features
@@ -2,3 +2,5 @@ aia
 sstc
 pci
 ecam_pcie
+iommu
+share_s2pt

--- a/platform/riscv64/qemu-aia/image/dts/zone0.dts
+++ b/platform/riscv64/qemu-aia/image/dts/zone0.dts
@@ -183,7 +183,7 @@
 	};
 
 	chosen {
-		bootargs = "root=/dev/vda rw earlycon console=ttyS0 pci=nomsi";
+		bootargs = "root=/dev/vda rw earlycon console=ttyS0";
 	};
 
 };

--- a/platform/riscv64/qemu-aia/image/dts/zone1-linux.dts
+++ b/platform/riscv64/qemu-aia/image/dts/zone1-linux.dts
@@ -90,6 +90,6 @@
 	};
 
 	chosen {
-		bootargs = "root=/dev/vda rw earlycon=virtio,mmio,0x10007000 console=hvc0 pci=nomsi";
+		bootargs = "root=/dev/vda rw earlycon=virtio,mmio,0x10007000 console=hvc0";
 	};
 };

--- a/platform/riscv64/qemu-aia/platform.mk
+++ b/platform/riscv64/qemu-aia/platform.mk
@@ -10,7 +10,7 @@ zone0_dtb    := $(image_dir)/dts/zone0.dtb
 # zone1_kernel := $(image_dir)/kernel/Image
 # zone1_dtb    := $(image_dir)/devicetree/linux.dtb
 
-QEMU_ARGS := -machine virt,aia=aplic-imsic,aia-guests=1
+QEMU_ARGS := -machine virt,aia=aplic-imsic,aia-guests=1,iommu-sys=on
 QEMU_ARGS += -bios default
 QEMU_ARGS += -cpu rv64
 QEMU_ARGS += -smp 4

--- a/platform/riscv64/qemu-aia/test/runner.sh
+++ b/platform/riscv64/qemu-aia/test/runner.sh
@@ -32,7 +32,7 @@ info "PWD=$PWD, running cargo test"
 $OBJCOPY $HVISOR_ELF --strip-all -O binary $HVISOR_BIN
 
 qemu-system-riscv64 \
-    -machine virt,aia=aplic-imsic,aia-guests=1,aclint=on \
+    -machine virt,aia=aplic-imsic,aia-guests=1,iommu-sys=on \
     -bios default -cpu rv64 -smp 4 -m 4G -nographic \
     -kernel $HVISOR_BIN
 

--- a/src/arch/riscv64/iommu.rs
+++ b/src/arch/riscv64/iommu.rs
@@ -129,6 +129,19 @@ register_bitfields![u64,
         ],
         PPN OFFSET(0) NUMBITS(44) []
     ],
+    DDT_MSIPTP [ // RISCV-IOMMU Spec Chap3.1.3.5 MSI page table pointer
+        MODE OFFSET(60) NUMBITS(4) [
+            OFF = 0,
+            FLAT = 1,
+        ],
+        PPN OFFSET(0) NUMBITS(44) [],
+    ],
+    DDT_MSI_ADDR_MASK [ // RISCV-IOMMU Spec Chap3.1.3.6 MSI address mask and pattern
+        MASK OFFSET(0) NUMBITS(52) [],
+    ],
+    DDT_MSI_ADDR_PATTERN [
+        PATTERN OFFSET(0) NUMBITS(52) [],
+    ],
     DDT_DIR [ // RISCV-IOMMU Spec Chap3.1.1 Non-leaf DDT entry
         V OFFSET(0) NUMBITS(1) [],
         PPN OFFSET(10) NUMBITS(44) []
@@ -429,9 +442,9 @@ struct DdtEntry {
     iohgatp: ReadWrite<u64, DDT_IOHGATP::Register>,
     ta: ReadWrite<u64>,
     fsc: ReadWrite<u64, DDT_FSC::Register>,
-    msiptp: ReadWrite<u64>,
-    msi_addr_mask: ReadWrite<u64>,
-    msi_addr_pattern: ReadWrite<u64>,
+    msiptp: ReadWrite<u64, DDT_MSIPTP::Register>,
+    msi_addr_mask: ReadWrite<u64, DDT_MSI_ADDR_MASK::Register>,
+    msi_addr_pattern: ReadWrite<u64, DDT_MSI_ADDR_PATTERN::Register>,
     __rsv: ReadWrite<u64>,
 }
 
@@ -639,6 +652,39 @@ impl Iommu {
         );
         // Bare first-stage context.
         entry.fsc.set(0x0);
+        #[cfg(feature = "aia")]
+        {
+            use crate::device::irqchip::aia::msi_pt_paddr_for_zone;
+
+            if let Some(msi_pt_paddr) = msi_pt_paddr_for_zone(vm_id) {
+                entry.msiptp.write(
+                    DDT_MSIPTP::MODE.val(DDT_MSIPTP::MODE::FLAT.value)
+                        + DDT_MSIPTP::PPN.val((msi_pt_paddr as u64) >> 12),
+                );
+            } else {
+                warn!(
+                    "RV IOMMU: no MSI_PT_MAP entry for zone {}, msiptp cleared",
+                    vm_id
+                );
+                entry.msiptp.set(0);
+            }
+            // (A >> 12) & ~msi_addr_mask = (msi_addr_pattern & ~msi_addr_mask)
+            let imsic_s_base_ppn = crate::platform::IMSIC_S_BASE >> 12; // Assume every Guest's vIMSIC_S base is the same as the global IMSIC_S_BASE.
+            let mask = (1usize
+                << crate::consts::MAX_CPU_NUM
+                    .next_power_of_two()
+                    .trailing_zeros())
+                - 1;
+            let pattern = imsic_s_base_ppn; // Here we assume that every Guest's vIMSIC_S base is the same.
+            entry
+                .msi_addr_mask
+                .write(DDT_MSI_ADDR_MASK::MASK.val(mask as u64));
+            entry
+                .msi_addr_pattern
+                .write(DDT_MSI_ADDR_PATTERN::PATTERN.val(pattern as u64));
+            info!("msiptp mode = {} msiptp ppn = {:#x}, msi_addr_mask = {:#x}, msi_addr_pattern = {:#x}", entry.msiptp.read(DDT_MSIPTP::MODE), entry.msiptp.read(DDT_MSIPTP::PPN), entry.msi_addr_mask.read(DDT_MSI_ADDR_MASK::MASK), entry.msi_addr_pattern.read(DDT_MSI_ADDR_PATTERN::PATTERN));
+        }
+
         entry.tc.write(DDT_TC::V::SET);
         info!(
             "RV IOMMU: Write DDT, add decive context, iohgatp.mode = {:#x?}, ioghatp.ppn = {:#x?}",
@@ -661,7 +707,13 @@ impl Iommu {
             );
             return;
         };
-        entry.tc.write(DDT_TC::V::CLEAR);
+        entry.ta.set(0x0);
+        entry.tc.set(0x0);
+        entry.fsc.set(0x0);
+        entry.iohgatp.set(0x0);
+        entry.msi_addr_mask.set(0x0);
+        entry.msi_addr_pattern.set(0x0);
+        entry.msiptp.set(0x0);
         info!(
             "RV IOMMU: Write DDT, remove decive context, iohgatp.mode = {:#x?}, ioghatp.ppn = {:#x?}",
             entry.iohgatp.read(DDT_IOHGATP::MODE),

--- a/src/device/irqchip/aia/mod.rs
+++ b/src/device/irqchip/aia/mod.rs
@@ -30,6 +30,7 @@ use crate::memory::HostPhysAddr;
 use crate::memory::MMIOAccess;
 use crate::memory::MemFlags;
 use crate::memory::MemoryRegion;
+use crate::memory::{Frame, PhysAddr};
 use crate::platform::HW_IRQS;
 use crate::platform::{
     BOARD_APLIC_INTERRUPTS_NUM, IMSIC_GUEST_INDEX, IMSIC_GUEST_NUM, IMSIC_S_BASE,
@@ -47,6 +48,15 @@ pub use vimsic::*;
 pub static APLIC: Once<Aplic> = Once::new();
 // The MAX_ZONE_NUM should be the power of 2.
 static mut VAPLIC_MAP: Option<FnvIndexMap<usize, VirtualAPLIC, MAX_ZONE_NUM>> = None;
+/// Per-zone IOMMU MSI page table (one 4 KiB frame, 16-byte PTEs; invalid entries are all-zero).
+static mut MSI_PT_MAP: Option<FnvIndexMap<usize, Frame, MAX_ZONE_NUM>> = None;
+
+/// Physical base of the MSI page-table frame for `zone_id` (`vm_id`), after `vimsic_init`.
+pub fn msi_pt_paddr_for_zone(zone_id: usize) -> Option<PhysAddr> {
+    // Once the MSI_PT for one zone is initialized, it wouldn't change.
+    // Here don't use lock, because it's read-only operation here.
+    unsafe { MSI_PT_MAP.as_ref()?.get(&zone_id).map(|f| f.start_paddr()) }
+}
 
 pub fn init_aplic(aplic_base: usize) {
     APLIC.call_once(|| Aplic::new(aplic_base));
@@ -64,6 +74,7 @@ pub fn primary_init_early() {
 
     unsafe {
         VAPLIC_MAP = Some(FnvIndexMap::new());
+        MSI_PT_MAP = Some(FnvIndexMap::new());
     }
 }
 
@@ -160,9 +171,21 @@ impl Zone {
     }
 
     /// Initial the virtual IMSIC related to thiz Zone.
-    pub fn vimsic_init(&mut self, config: &HvZoneConfig) {
+    pub fn vimsic_init(&mut self, _config: &HvZoneConfig) {
         info!("Zone {} vIMSIC init", self.id());
-        vimsic::vimsic_init(self, IMSIC_S_BASE, IMSIC_GUEST_NUM);
+        let msi_pt = vimsic::vimsic_init(self, IMSIC_S_BASE, IMSIC_GUEST_NUM);
+        unsafe {
+            if let Some(map) = &mut MSI_PT_MAP {
+                if map.contains_key(&self.id()) {
+                    panic!("MSI page table for Zone {} already exists!", self.id());
+                }
+                if map.insert(self.id(), msi_pt).is_err() {
+                    panic!("MSI_PT_MAP full");
+                }
+            } else {
+                panic!("MSI_PT_MAP is not initialized!");
+            }
+        }
     }
 
     pub fn get_vaplic(&self) -> &VirtualAPLIC {
@@ -208,6 +231,11 @@ impl Zone {
                 map.remove(&self.id());
             } else {
                 panic!("VAPLIC_MAP is not initialized!");
+            }
+            if let Some(map) = &mut MSI_PT_MAP {
+                let _ = map.remove(&self.id());
+            } else {
+                panic!("MSI_PT_MAP is not initialized!");
             }
         }
         print_keys();

--- a/src/device/irqchip/aia/vimsic.rs
+++ b/src/device/irqchip/aia/vimsic.rs
@@ -17,11 +17,64 @@
 use alloc::vec::Vec;
 
 use crate::consts::PAGE_SIZE;
+use crate::memory::Frame;
 use crate::memory::GuestPhysAddr;
 use crate::memory::MemFlags;
 use crate::memory::MemoryRegion;
 use crate::platform::__board::{IMSIC_GUEST_INDEX, IMSIC_GUEST_NUM, IMSIC_S_BASE};
 use crate::zone::Zone;
+
+/// RISC-V IOMMU MSI PTE size (two 64-bit doublewords).
+pub const MSI_PTE_BYTES: usize = 16;
+/// One 4 KiB page holds at most this many MSI PTEs (spec: table ≤256 entries uses one 4K page).
+pub const MSI_PTE_COUNT: usize = PAGE_SIZE / MSI_PTE_BYTES;
+
+/// Encode one MSI PTE in basic translation mode (V=1, C=0, M=3): replace GPA bits ≥12 with `PPN`.
+///
+/// DW0: bit0 V=1, bits 2:1 M=3, bits 53:10 PPN, bit 63 C=0. DW1 reserved (0).
+#[inline]
+pub fn msi_pte_encode_basic(hpa: usize) -> [u8; MSI_PTE_BYTES] {
+    let ppn = (hpa >> 12) as u64;
+    const PPN_MASK: u64 = (1u64 << 44) - 1;
+    // V=1, M=3, C=0, PPN=ppn
+    let dw0: u64 = 1 | (3 << 1) | ((ppn & PPN_MASK) << 10);
+    let mut out = [0u8; MSI_PTE_BYTES];
+    out[..8].copy_from_slice(&dw0.to_le_bytes());
+    out
+}
+
+/// Fill a 4 KiB MSI page table: PTE index is `vcpu_id = cpu_id - first_cpu` (guest ordinal).
+fn msi_pt_fill(
+    frame: &mut Frame,
+    cpu_ids: &[usize],
+    first_cpu: usize,
+    imsic_base: usize,
+    guest_num: usize,
+) {
+    frame.clear();
+    for &cpu_id in cpu_ids {
+        let vcpu_id = cpu_id - first_cpu;
+        assert!(
+            vcpu_id < MSI_PTE_COUNT,
+            "MSI PTE index (vcpu_id) {} exceeds table capacity {}",
+            vcpu_id,
+            MSI_PTE_COUNT
+        );
+        // IMSIC VS-file for global view.
+        let imsic_hpa = imsic_base + PAGE_SIZE * ((1 + guest_num) * cpu_id + IMSIC_GUEST_INDEX);
+        // VIMSIC S-file for guest view.
+        let imsic_gpa = imsic_base + PAGE_SIZE * vcpu_id;
+        // Construct MSI PTE.
+        let pte = msi_pte_encode_basic(imsic_hpa);
+        let off = vcpu_id * MSI_PTE_BYTES;
+        info!(
+            "vIMSIC map vcpu {} imsic hpa {:#x} gpa {:#x}",
+            vcpu_id, imsic_hpa, imsic_gpa
+        );
+        // Fill MSI PTE to MSI PT.
+        frame.as_slice_mut()[off..off + MSI_PTE_BYTES].copy_from_slice(&pte);
+    }
+}
 
 /**
  * For imsic's guest_num = 1
@@ -33,21 +86,30 @@ use crate::zone::Zone;
  *     ...
  */
 
-pub fn vimsic_init(zone: &mut Zone, imsic_base: usize, guest_num: usize) {
+/// Maps guest IMSIC interrupt files and builds a one-page IOMMU MSI translation table for this zone.
+///
+/// Returns the physical frame backing the MSI PTE array (`start_paddr()` for IOMMU programming).
+pub fn vimsic_init(zone: &mut Zone, imsic_base: usize, guest_num: usize) -> Frame {
     let size = crate::memory::PAGE_SIZE;
 
     let cpu_ids: Vec<_> = zone.cpu_set().iter().collect();
+    let first_cpu = zone
+        .cpu_set()
+        .first_cpu()
+        .expect("vimsic_init: zone has no CPUs");
     let mut inner = zone.write();
 
+    // 1. Insert regions to zone.gpm, this is used by cpu core (for example, send ipi through vimsic).
     cpu_ids.iter().for_each(|cpu_id| {
-        let vcpu_id = cpu_id; // In hvisor, vcpu_id == cpu_id.
+        let vcpu_id = cpu_id - first_cpu;
         let imsic_hpa = imsic_base + PAGE_SIZE * ((1 + guest_num) * cpu_id + IMSIC_GUEST_INDEX);
-        // For VM, it couldn't see VS-files.
-        let imsic_gpa = imsic_base + PAGE_SIZE * vcpu_id; // In hvisor, vcpu_id == cpu_id.
+        // For VM, it couldn't see VS-files. Guest uses contiguous indices from 0.
+        let imsic_gpa = imsic_base + PAGE_SIZE * vcpu_id;
         info!(
-            "Zone {} vIMSIC map hart {} imsic hpa {:#x} gpa {:#x}",
+            "Zone {} vIMSIC map phys_hart {} vcpu {} imsic hpa {:#x} gpa {:#x}",
             zone.id(),
             cpu_id,
+            vcpu_id,
             imsic_hpa,
             imsic_gpa
         );
@@ -58,6 +120,18 @@ pub fn vimsic_init(zone: &mut Zone, imsic_base: usize, guest_num: usize) {
             MemFlags::READ | MemFlags::WRITE,
         ));
     });
+    drop(inner);
+
+    // 2. Construct MSI PT, this is used by devices that send MSI.
+    let mut msi_frame = Frame::new_zero().expect("MSI page table frame allocation");
+    msi_pt_fill(&mut msi_frame, &cpu_ids, first_cpu, imsic_base, guest_num);
+    info!(
+        "Zone {} MSI page table at HPA {:#x} ({} valid PTEs, basic translation)",
+        zone.id(),
+        msi_frame.start_paddr(),
+        cpu_ids.len()
+    );
+    msi_frame
 }
 
 pub fn imsic_vs_file_addr(hart_id: usize) -> usize {


### PR DESCRIPTION
### Purpose
Add support for msi irq-remapping for riscv platform with aia and iommu.

The diagram below illustrates the basic process of MSI remapping. (Diagram from riscv iommu spec v1.0)

<img width="1280" height="607" alt="b6cdcdbf-4ea2-404a-a0f9-4527182239dc" src="https://github.com/user-attachments/assets/10e5a59b-c837-4dab-839c-822ae077f6e9" />

### Test Result

We can see that zone0 and zone1 are both using the root file system in the PCIe block device normally, and are correctly using PCI virtualization + iommu feature.

<img width="2768" height="856" alt="image" src="https://github.com/user-attachments/assets/41bebaa4-eee3-4ffc-a15f-741d0b5e305f" />
