### PR TITLE
Refine early boot assembly for aarch64

### DIFF
--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -25,7 +25,8 @@ pub unsafe extern "C" fn arch_entry() -> ! {
     unsafe {
         core::arch::asm!(
             "
-            // x0 = dtbaddr
+            // `arch_entry` receives dtbaddr in `x0`. Keep it in `x20` until `rust_main`.
+            // Note: Only callee-saved registers (x19-x28) are guaranteed to be preserved across function calls.
             mov x20, x0
 
             /* Insert nop instruction to ensure byte at offset 10 in hvisor binary is non-zero.
@@ -36,7 +37,8 @@ pub unsafe extern "C" fn arch_entry() -> ! {
 
             nop
             nop
-            bl {boot_cpuid_get}        // x19 = cpuid
+            // boot_cpuid_get returns the logical cpuid in `x19`.
+            bl {boot_cpuid_get}
 
             adrp x2, __core_end        // x2 = &__core_end
             mov x3, {per_cpu_size}     // x3 = per_cpu_size
@@ -47,13 +49,17 @@ pub unsafe extern "C" fn arch_entry() -> ! {
             // disable cache and MMU
             mrs x1, sctlr_el2
             bic x1, x1, #0xf
-            msr sctlr_el2, x1
+            msr sctlr_el2, x1           //  SCTLR_EL2 &= ~0xf;
+            isb
 
             // cache_invalidate(0): clear dl1$
             mov x0, #0
             bl  {cache_invalidate}
 
+            // invalidate all instruction caches to PoU, and ensure completion of the invalidation.
             ic  iallu
+            dsb sy
+            isb
 
             cmp x19, 0
             b.ne 1f
@@ -61,9 +67,6 @@ pub unsafe extern "C" fn arch_entry() -> ! {
             // if (cpu_id == 0) cache_invalidate(2): clear l2$
             mov x0, #2
             bl  {cache_invalidate}
-
-            // ic  iallu
-
             bl {clear_bss}
             bl {boot_pt_init}
         1:
@@ -94,6 +97,7 @@ pub unsafe extern "C" fn boot_cpuid_get() {
 
     core::arch::asm!(
         "
+        // Return convention for `arch_entry`: leave the logical cpuid in x19.
         mrs x19, mpidr_el1
         ldr x2, ={mpidr_mask}
         and x19, x19, x2
@@ -177,6 +181,7 @@ unsafe extern "C" fn cache_invalidate(cache_level: usize) {
     core::arch::asm!(
         r#"
         msr csselr_el1, {0}
+        isb
         mrs x4, ccsidr_el1 // read cache size id.
         and x1, x4, #0x7
         add x1, x1, #0x4 // x1 = cache line size.
@@ -202,6 +207,7 @@ unsafe extern "C" fn cache_invalidate(cache_level: usize) {
         add x5, x5, #1 // else, next way.
         cmp x5, x3 // last way reached yet?
         ble 1b // if not, iterate way_loop
+        dsb sy
         "#,
         in(reg) cache_level,
         options(nostack)

--- a/src/arch/aarch64/entry.rs
+++ b/src/arch/aarch64/entry.rs
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn arch_entry() -> ! {
         core::arch::asm!(
             "
             // x0 = dtbaddr
-            mov x18, x0
+            mov x20, x0
 
             /* Insert nop instruction to ensure byte at offset 10 in hvisor binary is non-zero.
             * Rockchip U-Boot (arch_preboot_os@arch/arm/mach-rockchip/board.c:670) performs 
@@ -36,7 +36,7 @@ pub unsafe extern "C" fn arch_entry() -> ! {
 
             nop
             nop
-            bl {boot_cpuid_get}        // x17 = cpuid
+            bl {boot_cpuid_get}        // x19 = cpuid
 
             adrp x2, __core_end        // x2 = &__core_end
             mov x3, {per_cpu_size}     // x3 = per_cpu_size
@@ -69,9 +69,9 @@ pub unsafe extern "C" fn arch_entry() -> ! {
         1:
             bl {mmu_enable}
 
-            mov x1, x18
+            mov x1, x20
             mov x0, x19
-            mov x18, #0
+            mov x20, #0
             mov x19, #0
             bl {rust_main}            // x0 = cpuid, x1 = dtbaddr
             ",


### PR DESCRIPTION
# Overview
- Fix corrupted boot args `dtbaddr` for `rust_main` in release mode
- Add necessary barrier(`dsb`/`isb`) to early boot assembly.
- btw, add some comments to describe convetions.

## Sync barriers
- Ensure reloading instructions after cache invalidation
- Ensure completion of some instuctions, e.g. `ic iallu`.

## Corrupted `dtbaddr`  

On AArch64, the `dtbaddr` retrieved during early boot may be corrupted in non-debug (optimized) builds.

### Root Cause

- `x18` is a caller-saved register per the AArch64 ABI.
- In hvisor, Its value is assumed to remain intact across calls during early boot.
- This assumption is invalid under optimization which compiler may use those registers to accelerate.
- As a result, x18—which temporarily holds the `dtbaddr`—is overwritten in the release mode.


### Resolution
The issue is resolved by:
 - Replacing the use of `x18` with `x20`, which is callee-saved according to the AArch64 calling convention.

### Note
- This problem is similar to https://github.com/syswonder/hvisor/issues/225.