### PR TITLE
Add overlap check between MMIO passthrough regions and MMIO intercept handler regions

### DIFF
--- a/src/arch/aarch64/ivc.rs
+++ b/src/arch/aarch64/ivc.rs
@@ -191,7 +191,7 @@ impl Zone {
                     PAGE_SIZE,
                     mmio_ivc_handler,
                     ivc_config.control_table_ipa as _,
-                );
+                )?;
             } else {
                 return hv_result_err!(EINVAL);
             }

--- a/src/arch/aarch64/zone.rs
+++ b/src/arch/aarch64/zone.rs
@@ -36,6 +36,17 @@ impl Zone {
             }
             match mem_region.mem_type {
                 MEM_TYPE_RAM | MEM_TYPE_IO => {
+                    // Check for overlap with registered MMIO handler regions.
+                    if inner.is_mmio_handler_overlap(
+                        mem_region.virtual_start as GuestPhysAddr,
+                        mem_region.size as _,
+                    ) {
+                        panic!(
+                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                            mem_region.virtual_start,
+                            mem_region.virtual_start as u64 + mem_region.size
+                        );
+                    }
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(

--- a/src/arch/aarch64/zone.rs
+++ b/src/arch/aarch64/zone.rs
@@ -35,34 +35,21 @@ impl Zone {
                 flags |= MemFlags::IO;
             }
             match mem_region.mem_type {
-                MEM_TYPE_RAM | MEM_TYPE_IO => {
-                    // Check for overlap with registered MMIO handler regions.
-                    if inner.is_mmio_handler_overlap(
+                MEM_TYPE_RAM | MEM_TYPE_IO => inner.insert_passthrough_region(
+                    MemoryRegion::new_with_offset_mapper(
                         mem_region.virtual_start as GuestPhysAddr,
+                        mem_region.physical_start as HostPhysAddr,
                         mem_region.size as _,
-                    ) {
-                        panic!(
-                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
-                            mem_region.virtual_start,
-                            mem_region.virtual_start as u64 + mem_region.size
-                        );
-                    }
-                    inner
-                        .gpm_mut()
-                        .insert(MemoryRegion::new_with_offset_mapper(
-                            mem_region.virtual_start as GuestPhysAddr,
-                            mem_region.physical_start as HostPhysAddr,
-                            mem_region.size as _,
-                            flags,
-                        ))?
-                }
+                        flags,
+                    ),
+                )?,
                 MEM_TYPE_VIRTIO => {
                     inner.mmio_region_register(
                         mem_region.physical_start as _,
                         mem_region.size as _,
                         mmio_virtio_handler,
                         mem_region.physical_start as _,
-                    );
+                    )?;
                 }
                 _ => {
                     // hvisor-tool should check memory type in advance.

--- a/src/arch/loongarch64/zone.rs
+++ b/src/arch/loongarch64/zone.rs
@@ -53,6 +53,17 @@ impl Zone {
             let mem_type = region.mem_type;
             match mem_type {
                 MEM_TYPE_RAM => {
+                    // Check for overlap with registered MMIO handler regions.
+                    if inner.is_mmio_handler_overlap(
+                        region.virtual_start as GuestPhysAddr,
+                        region.size as _,
+                    ) {
+                        panic!(
+                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                            region.virtual_start,
+                            region.virtual_start as u64 + region.size
+                        );
+                    }
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(
@@ -63,6 +74,17 @@ impl Zone {
                         ))?;
                 }
                 MEM_TYPE_IO => {
+                    // Check for overlap with registered MMIO handler regions.
+                    if inner.is_mmio_handler_overlap(
+                        region.virtual_start as GuestPhysAddr,
+                        region.size as _,
+                    ) {
+                        panic!(
+                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                            region.virtual_start,
+                            region.virtual_start as u64 + region.size
+                        );
+                    }
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(
@@ -77,6 +99,15 @@ impl Zone {
                         "loongarch64: pt_init: register virtio mmio region: {:#x?}",
                         region
                     );
+                    // Register the mmio handler first, so that the overlap check
+                    // against the stage-2 page table in mmio_region_register does
+                    // not find the VIRTIO trap page we are about to insert.
+                    inner.mmio_region_register(
+                        region.physical_start as _,
+                        region.size as _,
+                        mmio_virtio_handler,
+                        region.physical_start as _,
+                    );
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(
@@ -85,12 +116,6 @@ impl Zone {
                             PAGE_SIZE, // since we only need 0x200 size for virtio mmio, but the minimal size is PAGE_SIZE
                             MemFlags::USER, // we use the USER as a hint flag for invalidating this stage-2 PTE
                         ))?;
-                    inner.mmio_region_register(
-                        region.physical_start as _,
-                        region.size as _,
-                        mmio_virtio_handler,
-                        region.physical_start as _,
-                    );
                 }
                 _ => {
                     error!("loongarch64: pt_init: unknown mem type: {}", mem_type);

--- a/src/arch/loongarch64/zone.rs
+++ b/src/arch/loongarch64/zone.rs
@@ -71,9 +71,6 @@ impl Zone {
                         "loongarch64: pt_init: register virtio mmio region: {:#x?}",
                         region
                     );
-                    // Register the mmio handler first, so that the overlap check
-                    // against the stage-2 page table in mmio_region_register does
-                    // not find the VIRTIO trap page we are about to insert.
                     inner.mmio_region_register(
                         region.physical_start as _,
                         region.size as _,

--- a/src/arch/loongarch64/zone.rs
+++ b/src/arch/loongarch64/zone.rs
@@ -52,48 +52,20 @@ impl Zone {
             trace!("loongarch64: pt_init: process region: {:#x?}", region);
             let mem_type = region.mem_type;
             match mem_type {
-                MEM_TYPE_RAM => {
-                    // Check for overlap with registered MMIO handler regions.
-                    if inner.is_mmio_handler_overlap(
+                MEM_TYPE_RAM => inner.insert_passthrough_region(
+                    MemoryRegion::new_with_offset_mapper(
                         region.virtual_start as GuestPhysAddr,
+                        region.physical_start as HostPhysAddr,
                         region.size as _,
-                    ) {
-                        panic!(
-                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
-                            region.virtual_start,
-                            region.virtual_start as u64 + region.size
-                        );
-                    }
-                    inner
-                        .gpm_mut()
-                        .insert(MemoryRegion::new_with_offset_mapper(
-                            region.virtual_start as GuestPhysAddr,
-                            region.physical_start as HostPhysAddr,
-                            region.size as _,
-                            MemFlags::READ | MemFlags::WRITE | MemFlags::EXECUTE,
-                        ))?;
-                }
-                MEM_TYPE_IO => {
-                    // Check for overlap with registered MMIO handler regions.
-                    if inner.is_mmio_handler_overlap(
-                        region.virtual_start as GuestPhysAddr,
-                        region.size as _,
-                    ) {
-                        panic!(
-                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
-                            region.virtual_start,
-                            region.virtual_start as u64 + region.size
-                        );
-                    }
-                    inner
-                        .gpm_mut()
-                        .insert(MemoryRegion::new_with_offset_mapper(
-                            region.virtual_start as GuestPhysAddr,
-                            region.physical_start as HostPhysAddr,
-                            region.size as _,
-                            MemFlags::READ | MemFlags::WRITE | MemFlags::IO,
-                        ))?;
-                }
+                        MemFlags::READ | MemFlags::WRITE | MemFlags::EXECUTE,
+                    ),
+                )?,
+                MEM_TYPE_IO => inner.insert_passthrough_region(MemoryRegion::new_with_offset_mapper(
+                    region.virtual_start as GuestPhysAddr,
+                    region.physical_start as HostPhysAddr,
+                    region.size as _,
+                    MemFlags::READ | MemFlags::WRITE | MemFlags::IO,
+                ))?,
                 MEM_TYPE_VIRTIO => {
                     info!(
                         "loongarch64: pt_init: register virtio mmio region: {:#x?}",
@@ -107,7 +79,7 @@ impl Zone {
                         region.size as _,
                         mmio_virtio_handler,
                         region.physical_start as _,
-                    );
+                    )?;
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(
@@ -130,7 +102,7 @@ impl Zone {
         // 3. chip configuration
 
         info!("loongarch64: pt_init: add mmio handler for 0x1fe0_xxxx mmio region");
-        inner.mmio_region_register(0x1fe0_0000, 0x3000, loongarch_generic_mmio_handler, 0x1234);
+        inner.mmio_region_register(0x1fe0_0000, 0x3000, loongarch_generic_mmio_handler, 0x1234)?;
 
         info!("zone stage-2 memory set: {:#x?}", inner.gpm());
         unsafe {

--- a/src/arch/riscv64/zone.rs
+++ b/src/arch/riscv64/zone.rs
@@ -31,34 +31,21 @@ impl Zone {
                 flags |= MemFlags::EXECUTE;
             }
             match mem_region.mem_type {
-                MEM_TYPE_RAM | MEM_TYPE_IO => {
-                    // Check for overlap with registered MMIO handler regions.
-                    if inner.is_mmio_handler_overlap(
+                MEM_TYPE_RAM | MEM_TYPE_IO => inner.insert_passthrough_region(
+                    MemoryRegion::new_with_offset_mapper(
                         mem_region.virtual_start as GuestPhysAddr,
+                        mem_region.physical_start as HostPhysAddr,
                         mem_region.size as _,
-                    ) {
-                        panic!(
-                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
-                            mem_region.virtual_start,
-                            mem_region.virtual_start as u64 + mem_region.size
-                        );
-                    }
-                    inner
-                        .gpm_mut()
-                        .insert(MemoryRegion::new_with_offset_mapper(
-                            mem_region.virtual_start as GuestPhysAddr,
-                            mem_region.physical_start as HostPhysAddr,
-                            mem_region.size as _,
-                            flags,
-                        ))?
-                }
+                        flags,
+                    ),
+                )?,
                 MEM_TYPE_VIRTIO => {
                     inner.mmio_region_register(
                         mem_region.physical_start as _,
                         mem_region.size as _,
                         mmio_virtio_handler,
                         mem_region.physical_start as _,
-                    );
+                    )?;
                 }
                 _ => {
                     panic!("Unsupported memory type: {}", mem_region.mem_type)

--- a/src/arch/riscv64/zone.rs
+++ b/src/arch/riscv64/zone.rs
@@ -32,6 +32,17 @@ impl Zone {
             }
             match mem_region.mem_type {
                 MEM_TYPE_RAM | MEM_TYPE_IO => {
+                    // Check for overlap with registered MMIO handler regions.
+                    if inner.is_mmio_handler_overlap(
+                        mem_region.virtual_start as GuestPhysAddr,
+                        mem_region.size as _,
+                    ) {
+                        panic!(
+                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                            mem_region.virtual_start,
+                            mem_region.virtual_start as u64 + mem_region.size
+                        );
+                    }
                     inner
                         .gpm_mut()
                         .insert(MemoryRegion::new_with_offset_mapper(

--- a/src/arch/x86_64/zone.rs
+++ b/src/arch/x86_64/zone.rs
@@ -72,23 +72,12 @@ impl Zone {
             }
             match mem_region.mem_type {
                 MEM_TYPE_RAM | MEM_TYPE_IO | MEM_TYPE_RESERVED => {
-                    // Check for overlap with registered MMIO handler regions.
-                    if inner.is_mmio_handler_overlap(
-                        mem_region.virtual_start as GuestPhysAddr,
-                        mem_region.size as _,
-                    ) {
-                        panic!(
-                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
-                            mem_region.virtual_start,
-                            mem_region.virtual_start as u64 + mem_region.size
-                        );
-                    }
-                    inner.gpm_mut().insert(MemoryRegion::new_with_offset_mapper(
+                    inner.insert_passthrough_region(MemoryRegion::new_with_offset_mapper(
                         mem_region.virtual_start as GuestPhysAddr,
                         mem_region.physical_start as HostPhysAddr,
                         mem_region.size as _,
                         flags,
-                    ));
+                    ))?
                 }
                 MEM_TYPE_VIRTIO => {
                     info!(
@@ -100,7 +89,7 @@ impl Zone {
                         mem_region.size as _,
                         mmio_virtio_handler,
                         mem_region.physical_start as _,
-                    );
+                    )?;
                 }
                 _ => {
                     panic!("Unsupported memory type: {}", mem_region.mem_type)

--- a/src/arch/x86_64/zone.rs
+++ b/src/arch/x86_64/zone.rs
@@ -72,6 +72,17 @@ impl Zone {
             }
             match mem_region.mem_type {
                 MEM_TYPE_RAM | MEM_TYPE_IO | MEM_TYPE_RESERVED => {
+                    // Check for overlap with registered MMIO handler regions.
+                    if inner.is_mmio_handler_overlap(
+                        mem_region.virtual_start as GuestPhysAddr,
+                        mem_region.size as _,
+                    ) {
+                        panic!(
+                            "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                            mem_region.virtual_start,
+                            mem_region.virtual_start as u64 + mem_region.size
+                        );
+                    }
                     inner.gpm_mut().insert(MemoryRegion::new_with_offset_mapper(
                         mem_region.virtual_start as GuestPhysAddr,
                         mem_region.physical_start as HostPhysAddr,

--- a/src/device/eic7700_syscrg.rs
+++ b/src/device/eic7700_syscrg.rs
@@ -96,19 +96,20 @@ pub fn virtual_hsp_sp_top_csr_handler(mmio: &mut MMIOAccess, _arg: usize) -> HvR
 
 impl Zone {
     /// Initialize syscon MMIO region.
-    pub fn virtual_syscon_mmio_init(&mut self) {
+    pub fn virtual_syscon_mmio_init(&mut self) -> HvResult {
         let mut inner = self.write();
         inner.mmio_region_register(
             EIC7700_SYSCRG_BASE,
             EIC7700_SYSCRG_SIZE,
             virtual_syscrg_handler,
             0,
-        );
+        )?;
         inner.mmio_region_register(
             EIC7700_HSP_SP_TOP_CSR_BASE,
             EIC7700_HSP_SP_TOP_CSR_SIZE,
             virtual_hsp_sp_top_csr_handler,
             0,
-        );
+        )?;
+        Ok(())
     }
 }

--- a/src/device/iommu/arm_smmu/mod.rs
+++ b/src/device/iommu/arm_smmu/mod.rs
@@ -20,6 +20,7 @@ mod smmu_hw;
 
 use super::Iommu;
 use crate::cpu_data::this_zone;
+use crate::error::HvResult;
 use crate::memory::Frame;
 use crate::zone::Zone;
 use alloc::vec::Vec;
@@ -90,7 +91,12 @@ impl Iommu for ArmSmmu {
             zone_id
         );
     }
-    fn viommu_mmio_handler_register(&self, zone: &Zone, _viommu_base: usize, _viommu_size: usize) {
+    fn viommu_mmio_handler_register(
+        &self,
+        zone: &Zone,
+        _viommu_base: usize,
+        _viommu_size: usize,
+    ) -> HvResult {
         todo!(
             "ArmSmmu viommu handler for zone id {} not implemented yet.",
             zone.id()

--- a/src/device/iommu/dummy_iommu.rs
+++ b/src/device/iommu/dummy_iommu.rs
@@ -15,6 +15,7 @@
 //      Jingyu Liu <liujingyu24s@ict.ac.cn>
 
 use super::Iommu;
+use crate::error::HvResult;
 use crate::memory::{GuestPhysAddr, MemoryRegion};
 use crate::zone::Zone;
 use alloc::vec::Vec;
@@ -51,7 +52,13 @@ impl Iommu for DummyIommu {
     fn viommu_remove(&self, zone_id: usize) {
         info!("No IOMMU implementation available, cannot remove VIOMMU for Zone id {}", zone_id);
     }
-    fn viommu_mmio_handler_register(&self, zone: &Zone, _viommu_base: usize, _viommu_size: usize) {        
+    fn viommu_mmio_handler_register(
+        &self,
+        zone: &Zone,
+        _viommu_base: usize,
+        _viommu_size: usize,
+    ) -> HvResult {
         info!("No IOMMU implementation available, cannot handle VIOMMU MMIO for Zone id {}", zone.id());
+        Ok(())
     }
 }

--- a/src/device/iommu/intel_vtd/mod.rs
+++ b/src/device/iommu/intel_vtd/mod.rs
@@ -20,6 +20,7 @@ mod vtd_hw;
 
 use super::Iommu;
 use crate::cpu_data::this_zone;
+use crate::error::HvResult;
 use crate::memory::Frame;
 use crate::zone::Zone;
 use alloc::vec::Vec;
@@ -91,7 +92,12 @@ impl Iommu for IntelVtd {
             zone_id
         );
     }
-    fn viommu_mmio_handler_register(&self, zone: &Zone, _viommu_base: usize, _viommu_size: usize) {
+    fn viommu_mmio_handler_register(
+        &self,
+        zone: &Zone,
+        _viommu_base: usize,
+        _viommu_size: usize,
+    ) -> HvResult {
         todo!(
             "IntelVtd viommu handler for zone id {} not implemented yet.",
             zone.id()

--- a/src/device/iommu/iommu_trait.rs
+++ b/src/device/iommu/iommu_trait.rs
@@ -14,6 +14,7 @@
 // Authors:
 //      Jingyu Liu <liujingyu24s@ict.ac.cn>
 
+use crate::error::HvResult;
 use crate::memory::{GuestPhysAddr, MemoryRegion};
 use crate::zone::Zone;
 use alloc::vec::Vec;
@@ -39,5 +40,10 @@ pub(crate) trait Iommu {
     /// Remove the Virtual IOMMU for the Zone
     fn viommu_remove(&self, zone_id: usize);
     /// Register the Virtual IOMMU MMIO handler for the Zone
-    fn viommu_mmio_handler_register(&self, zone: &Zone, viommu_base: usize, viommu_size: usize);
+    fn viommu_mmio_handler_register(
+        &self,
+        zone: &Zone,
+        viommu_base: usize,
+        viommu_size: usize,
+    ) -> HvResult;
 }

--- a/src/device/iommu/mod.rs
+++ b/src/device/iommu/mod.rs
@@ -22,6 +22,7 @@ mod iommu_impl;
 mod iommu_trait;
 
 use crate::consts::MAX_ZONE_NUM;
+use crate::error::HvResult;
 use crate::zone::Zone;
 use iommu_impl::iommu_impl;
 use iommu_trait::Iommu;
@@ -85,8 +86,12 @@ pub(crate) fn viommu_remove(zone_id: usize) {
     }
 }
 
-pub(crate) fn viommu_mmio_handler_register(zone: &Zone, viommu_base: usize, viommu_size: usize) {
-    iommu_impl().viommu_mmio_handler_register(zone, viommu_base, viommu_size);
+pub(crate) fn viommu_mmio_handler_register(
+    zone: &Zone,
+    viommu_base: usize,
+    viommu_size: usize,
+) -> HvResult {
+    iommu_impl().viommu_mmio_handler_register(zone, viommu_base, viommu_size)
 }
 
 /////////////////////////////////////////////////////////////////////////

--- a/src/device/iommu/riscv_iommu/mod.rs
+++ b/src/device/iommu/riscv_iommu/mod.rs
@@ -34,6 +34,7 @@ mod reg_bits;
 mod viommu;
 
 use super::Iommu;
+use crate::error::HvResult;
 use crate::zone::Zone;
 use cmd::*;
 use iommu_hw::*;
@@ -102,10 +103,16 @@ impl Iommu for RiscvIommu {
             zone_id
         );
     }
-    fn viommu_mmio_handler_register(&self, zone: &Zone, viommu_base: usize, viommu_size: usize) {
+    fn viommu_mmio_handler_register(
+        &self,
+        zone: &Zone,
+        viommu_base: usize,
+        viommu_size: usize,
+    ) -> HvResult {
         #[cfg(viommu)]
-        viommu_mmio_handler_register(zone, viommu_base, viommu_size);
+        viommu_mmio_handler_register(zone, viommu_base, viommu_size)?;
         #[cfg(not(viommu))]
         warn!("Virtual IOMMU is not enabled, skipping viommu mmio handler for zone {}, viommu_base {}, viommu_size {}.", zone.id(), viommu_base, viommu_size);
+        Ok(())
     }
 }

--- a/src/device/iommu/riscv_iommu/viommu.rs
+++ b/src/device/iommu/riscv_iommu/viommu.rs
@@ -213,9 +213,13 @@ pub(super) fn viommu_remove(zone_id: usize) {
 }
 
 /// Register viommu mmio handler for target zone.
-pub(super) fn viommu_mmio_handler_register(zone: &Zone, viommu_base: usize, viommu_size: usize) {
+pub(super) fn viommu_mmio_handler_register(
+    zone: &Zone,
+    viommu_base: usize,
+    viommu_size: usize,
+) -> HvResult {
     zone.write()
-        .mmio_region_register(viommu_base, viommu_size, viommu_emul_handler, zone.id());
+        .mmio_region_register(viommu_base, viommu_size, viommu_emul_handler, zone.id())
 }
 
 /// Handle Zone's iommu mmio access.
@@ -602,7 +606,17 @@ impl VirtualIommuInner {
         // SAFETY: flush stage-2 translations after changing guest mappings.
         unsafe { riscv_h::asm::hfence_gvma(0, 0) };
         // Keep zone_id as 0 for now to preserve current behavior.
-        zone_inner.mmio_region_register(ddt_gpa, VIOMMU_DDT1LVL_SIZE, viommu_ddt_emul_handler, 0);
+        if let Err(err) = zone_inner.mmio_region_register(
+            ddt_gpa,
+            VIOMMU_DDT1LVL_SIZE,
+            viommu_ddt_emul_handler,
+            0,
+        ) {
+            error!("vIOMMU ddtp mmio handler register failed: {:?}", err);
+            send_event_to_all(cpu_set, 0, IPI_EVENT_VCPU_RESUME);
+            signal_other_vcpus_resume(cpu_set);
+            return false;
+        }
         send_event_to_all(cpu_set, 0, IPI_EVENT_VCPU_RESUME);
         signal_other_vcpus_resume(cpu_set);
         true

--- a/src/device/irqchip/aia/mod.rs
+++ b/src/device/irqchip/aia/mod.rs
@@ -278,11 +278,11 @@ impl Zone {
         }
     }
 
-    pub fn vaplic_mmio_init(&mut self, arch: &HvArchZoneConfig) {
+    pub fn vaplic_mmio_init(&mut self, arch: &HvArchZoneConfig) -> HvResult {
         if arch.aplic_base == 0 {
             panic!("vplic_mmio_init: plic_base is null");
         }
         self.write()
-            .mmio_region_register(arch.aplic_base, arch.aplic_size, vaplic_handler, 0);
+            .mmio_region_register(arch.aplic_base, arch.aplic_size, vaplic_handler, 0)
     }
 }

--- a/src/device/irqchip/gicv2/vgic.rs
+++ b/src/device/irqchip/gicv2/vgic.rs
@@ -39,7 +39,7 @@ const GICV2_REG_WIDTH: usize = 4;
 
 impl Zone {
     // trap all Guest OS accesses to the GIC Distributor registers.
-    pub fn vgicv2_mmio_init(&mut self, arch: &HvArchZoneConfig) {
+    pub fn vgicv2_mmio_init(&mut self, arch: &HvArchZoneConfig) -> HvResult {
         let zone_id = self.id();
         let mut inner = self.write();
         match arch.gic_config {
@@ -56,9 +56,10 @@ impl Zone {
                     gicv2_config.gicd_size,
                     vgicv2_dist_handler,
                     0,
-                );
+                )?;
             }
         }
+        Ok(())
     }
 
     // remap the GIC CPU interface register address space to point to the GIC virtual CPU interface registers.

--- a/src/device/irqchip/gicv3/vgic.rs
+++ b/src/device/irqchip/gicv3/vgic.rs
@@ -36,7 +36,7 @@ pub fn reg_range(base: usize, n: usize, size: usize) -> core::ops::Range<usize> 
 }
 
 impl Zone {
-    pub fn vgicv3_mmio_init(&mut self, arch: &HvArchZoneConfig) {
+    pub fn vgicv3_mmio_init(&mut self, arch: &HvArchZoneConfig) -> HvResult {
         let mut inner = self.write();
         match arch.gic_config {
             GicConfig::Gicv2(_) => {
@@ -54,13 +54,13 @@ impl Zone {
                     gicv3_config.gicd_size,
                     vgicv3_dist_handler,
                     0,
-                );
+                )?;
                 inner.mmio_region_register(
                     gicv3_config.gits_base,
                     gicv3_config.gits_size,
                     vgicv3_its_handler,
                     0,
-                );
+                )?;
 
                 for cpu in 0..MAX_CPU_NUM {
                     let gicr_base = host_gicr_base(cpu);
@@ -73,7 +73,7 @@ impl Zone {
                         PER_GICR_SIZE,
                         vgicv3_redist_handler,
                         cpu,
-                    );
+                    )?;
                 }
 
                 for base in CPU_UNUSED_GICR_BASE.iter() {
@@ -91,6 +91,7 @@ impl Zone {
                 }
             }
         }
+        Ok(())
     }
 
     pub fn irq_bitmap_init(&mut self, irqs_bitmap: &[BitmapWord]) {

--- a/src/device/irqchip/mod.rs
+++ b/src/device/irqchip/mod.rs
@@ -15,6 +15,7 @@
 //
 use crate::arch::zone::HvArchZoneConfig;
 use crate::config::HvZoneConfig;
+use crate::error::HvResult;
 use crate::zone::Zone;
 
 #[cfg(target_arch = "loongarch64")]
@@ -94,36 +95,37 @@ impl Zone {
         }
     }
 
-    pub fn mmio_init(&mut self, hv_config: &HvArchZoneConfig) {
+    pub fn mmio_init(&mut self, hv_config: &HvArchZoneConfig) -> HvResult {
         #[cfg(all(irq_gicv2, target_arch = "aarch64"))]
         {
-            self.vgicv2_mmio_init(hv_config);
+            self.vgicv2_mmio_init(hv_config)?;
             self.vgicv2_remap_init(hv_config);
         }
         #[cfg(all(irq_gicv3, target_arch = "aarch64"))]
         {
-            self.vgicv3_mmio_init(hv_config);
+            self.vgicv3_mmio_init(hv_config)?;
         }
         #[cfg(all(plic, target_arch = "riscv64"))]
         {
-            self.vplic_mmio_init(hv_config);
+            self.vplic_mmio_init(hv_config)?;
         }
         #[cfg(all(aia, target_arch = "riscv64"))]
         {
-            self.vaplic_mmio_init(hv_config);
+            self.vaplic_mmio_init(hv_config)?;
         }
         #[cfg(all(hypervisor_v0_6, target_arch = "riscv64"))]
         {
             #[cfg(sifive_ccache)]
-            self.virtual_sifive_ccache_mmio_init();
+            self.virtual_sifive_ccache_mmio_init()?;
             #[cfg(eic7700_sysreg)]
-            self.virtual_syscon_mmio_init();
+            self.virtual_syscon_mmio_init()?;
         }
         #[cfg(target_arch = "x86_64")]
         {
-            self.ioapic_mmio_init(hv_config);
+            self.ioapic_mmio_init(hv_config)?;
             // self.pci_config_space_mmio_init(hv_config);
         }
+        Ok(())
     }
 }
 

--- a/src/device/irqchip/pic/ioapic.rs
+++ b/src/device/irqchip/pic/ioapic.rs
@@ -201,16 +201,16 @@ impl VirtIoApic {
 }
 
 impl Zone {
-    pub fn ioapic_mmio_init(&mut self, arch: &HvArchZoneConfig) {
+    pub fn ioapic_mmio_init(&mut self, arch: &HvArchZoneConfig) -> HvResult {
         if arch.ioapic_base == 0 || arch.ioapic_size == 0 {
-            return;
+            return Ok(());
         }
         self.write().mmio_region_register(
             arch.ioapic_base,
             arch.ioapic_size,
             mmio_ioapic_handler,
             arch.ioapic_base,
-        );
+        )
     }
 }
 

--- a/src/device/irqchip/plic/mod.rs
+++ b/src/device/irqchip/plic/mod.rs
@@ -301,11 +301,11 @@ impl Zone {
         }
     }
 
-    pub fn vplic_mmio_init(&mut self, arch: &HvArchZoneConfig) {
+    pub fn vplic_mmio_init(&mut self, arch: &HvArchZoneConfig) -> HvResult {
         if arch.plic_base == 0 {
             panic!("vplic_mmio_init: plic_base is null");
         }
         self.write()
-            .mmio_region_register(arch.plic_base, arch.plic_size, vplic_handler, 0);
+            .mmio_region_register(arch.plic_base, arch.plic_size, vplic_handler, 0)
     }
 }

--- a/src/device/sifive_ccache/mod.rs
+++ b/src/device/sifive_ccache/mod.rs
@@ -85,12 +85,12 @@ pub fn virtual_sifive_ccache_handler(mmio: &mut MMIOAccess, _arg: usize) -> HvRe
 
 impl Zone {
     /// Initialize cache controller MMIO region.
-    pub fn virtual_sifive_ccache_mmio_init(&mut self) {
+    pub fn virtual_sifive_ccache_mmio_init(&mut self) -> HvResult {
         self.write().mmio_region_register(
             SIFIVE_CCACHE_BASE,
             SIFIVE_CCACHE_SIZE,
             virtual_sifive_ccache_handler,
             0,
-        );
+        )
     }
 }

--- a/src/memory/mm.rs
+++ b/src/memory/mm.rs
@@ -93,6 +93,30 @@ where
         self.pt.root_paddr()
     }
 
+    /// Check whether `[start, start+size)` overlaps with any existing region in this MemorySet.
+    pub fn is_range_overlap(&self, start: usize, size: usize) -> bool
+    where
+        PT::VA: From<usize>,
+    {
+        let end = start + size;
+        let va_start: PT::VA = start.into();
+        // Check the region immediately before `start`.
+        if let Some((_, before)) = self.regions.range(..va_start).last() {
+            let before_end: usize = before.start.into() + before.size;
+            if before_end > start {
+                return true;
+            }
+        }
+        // Check the region at or after `start`.
+        if let Some((_, after)) = self.regions.range(va_start..).next() {
+            let after_start: usize = after.start.into();
+            if after_start < end {
+                return true;
+            }
+        }
+        false
+    }
+
     fn test_free_area(&self, other: &MemoryRegion<PT::VA>) -> bool {
         if let Some((_, before)) = self.regions.range(..other.start).last() {
             if before.is_overlap_with(other) {

--- a/src/memory/mmio.rs
+++ b/src/memory/mmio.rs
@@ -51,6 +51,13 @@ impl MMIORegion {
     pub fn contains_region(&self, addr: GuestPhysAddr, sz: usize) -> bool {
         addr >= self.start && addr + (sz as usize) <= self.start + (self.size as usize)
     }
+
+    /// Check whether this region overlaps with `other`.
+    pub fn is_overlap_with(&self, other: &MMIORegion) -> bool {
+        let self_end = self.start + self.size;
+        let other_end = other.start + other.size;
+        !(self_end <= other.start || self.start >= other_end)
+    }
 }
 
 pub fn mmio_perform_access(base: usize, mmio: &mut MMIOAccess) {

--- a/src/pci/pci_access.rs
+++ b/src/pci/pci_access.rs
@@ -133,11 +133,13 @@ pub struct PciMem {
 }
 
 impl PciMem {
-    pub fn write(&mut self, value: u32) {
+    pub fn write(&mut self, value: u32) -> HvResult {
         if value == 0xffff_ffff {
             self.set_size_read();
+            Ok(())
         } else if value == 0x0 {
             // do nothing
+            Ok(())
         } else {
             match self.handler {
                 Some(handler) => {
@@ -148,13 +150,15 @@ impl PciMem {
                         self.size as usize,
                         handler,
                         value as usize,
-                    );
+                    )?;
                     drop(guard);
                     self.clear_size_read();
                     self.set_virtual_value(value as u64);
+                    Ok(())
                 }
                 None => {
                     warn!("This bar has not register handler!");
+                    Ok(())
                 }
             }
         }
@@ -470,8 +474,8 @@ pub struct Bar {
 }
 
 impl Bar {
-    pub fn write_bar(&mut self, index: usize, value: u32) {
-        self.bararr[index].write(value);
+    pub fn write_bar(&mut self, index: usize, value: u32) -> HvResult {
+        self.bararr[index].write(value)
     }
 
     pub fn read_bar(&self, index: usize) -> u32 {

--- a/src/pci/pci_config.rs
+++ b/src/pci/pci_config.rs
@@ -444,7 +444,7 @@ impl Zone {
         &mut self,
         pci_rootcomplex_config: &[HvPciConfig; CONFIG_PCI_BUS_MAXNUM],
         _num_pci_config: usize,
-    ) {
+    ) -> HvResult {
         #[cfg(loongarch64_pcie)]
         let mut emergency_map_regions: Vec<(usize, usize)> = Vec::new();
 
@@ -464,7 +464,7 @@ impl Zone {
                     mmio_vpci_handler,
                     // mmio_vpci_direct_handler,
                     rootcomplex_config.ecam_base as usize,
-                );
+                )?;
             }
             #[cfg(dwc_pcie)]
             {
@@ -478,7 +478,7 @@ impl Zone {
                     rootcomplex_config.ecam_size as usize,
                     mmio_vpci_handler_dbi,
                     encoded_arg,
-                );
+                )?;
 
                 let extend_config = platform::ROOT_DWC_ATU_CONFIG
                     .iter()
@@ -491,7 +491,7 @@ impl Zone {
                             extend_config.apb_size as usize,
                             mmio_generic_handler,
                             extend_config.apb_base as usize,
-                        );
+                        )?;
                     }
 
                     let cfg_size_half = extend_config.cfg_size / 2;
@@ -502,7 +502,7 @@ impl Zone {
                             cfg_size_half as usize,
                             mmio_dwc_cfg_handler,
                             cfg0_base as usize,
-                        );
+                        )?;
                     }
 
                     let cfg1_base = extend_config.cfg_base + cfg_size_half;
@@ -512,7 +512,7 @@ impl Zone {
                             cfg_size_half as usize,
                             mmio_dwc_cfg_handler,
                             cfg1_base as usize,
-                        );
+                        )?;
                     }
 
                     if extend_config.io_cfg_atu_shared != 0 {
@@ -521,7 +521,7 @@ impl Zone {
                             rootcomplex_config.io_size as usize,
                             mmio_dwc_io_handler,
                             rootcomplex_config.io_base as usize,
-                        );
+                        )?;
                     }
 
                     let mut atu = AtuConfig::default();
@@ -558,7 +558,7 @@ impl Zone {
                     rootcomplex_config.ecam_size as usize,
                     mmio_vpci_direct_handler,
                     rootcomplex_config.ecam_base as usize,
-                );
+                )?;
                 emergency_map_regions.push((
                     rootcomplex_config.ecam_base as usize,
                     rootcomplex_config.ecam_size as usize,
@@ -580,5 +580,7 @@ impl Zone {
                 let _ = self.page_table_emergency(base, size);
             }
         }
+
+        Ok(())
     }
 }

--- a/src/pci/pci_handler.rs
+++ b/src/pci/pci_handler.rs
@@ -141,7 +141,7 @@ fn handle_virtio_pci_write(
 ) -> HvResult<Option<usize>> {
     match EndpointField::from(offset as usize, size) {
         EndpointField::Bar(n) => dev.with_bar_ref_mut(n, |x| {
-            x.write(value as u32);
+            x.write(value as u32)?;
             Ok(Some(0))
         }),
         _ => {
@@ -774,7 +774,7 @@ fn handle_endpoint_access(
                                         bar_size as usize,
                                         mmio_msix_table_handler,
                                         paddr as usize,
-                                    );
+                                    )?;
                                 } else {
                                     let gpm = guard.gpm_mut();
                                     if !gpm
@@ -784,7 +784,7 @@ fn handle_endpoint_access(
                                         )
                                         .is_ok()
                                     {}
-                                    gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                    guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                         new_vaddr_aligned as GuestPhysAddr,
                                         paddr as HostPhysAddr,
                                         bar_size as _,
@@ -911,7 +911,7 @@ fn handle_endpoint_access(
                                         bar_size as usize,
                                         mmio_msix_table_handler,
                                         paddr as usize,
-                                    );
+                                    )?;
                                 } else {
                                     // Delete old gpm mapping if it exists
                                     let gpm = guard.gpm_mut();
@@ -925,7 +925,7 @@ fn handle_endpoint_access(
                                         // warn!("delete bar {}: can not found 0x{:x}", slot, old_vaddr);
                                     }
                                     // Insert new gpm mapping at new address
-                                    gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                    guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                         new_vaddr as GuestPhysAddr,
                                         paddr as HostPhysAddr,
                                         bar_size as _,
@@ -1072,7 +1072,7 @@ fn handle_endpoint_access(
                                 {
                                     // warn!("delete rom bar: can not found 0x{:x}", old_vaddr);
                                 }
-                                gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                     new_vaddr_aligned as GuestPhysAddr,
                                     paddr as HostPhysAddr,
                                     rom_size as _,
@@ -1270,7 +1270,7 @@ fn handle_pci_bridge_access(
                                         bar_size as usize,
                                         mmio_msix_table_handler,
                                         paddr as usize,
-                                    );
+                                    )?;
                                 } else {
                                     let gpm = guard.gpm_mut();
                                     if !gpm
@@ -1280,7 +1280,7 @@ fn handle_pci_bridge_access(
                                         )
                                         .is_ok()
                                     {}
-                                    gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                    guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                         new_vaddr_aligned as GuestPhysAddr,
                                         paddr as HostPhysAddr,
                                         bar_size as _,
@@ -1387,7 +1387,7 @@ fn handle_pci_bridge_access(
                                         bar_size as usize,
                                         mmio_msix_table_handler,
                                         paddr as usize,
-                                    );
+                                    )?;
                                 } else {
                                     // Delete old gpm mapping if it exists
                                     let gpm = guard.gpm_mut();
@@ -1401,7 +1401,7 @@ fn handle_pci_bridge_access(
                                         // warn!("delete bar {}: can not found 0x{:x}", slot, old_vaddr);
                                     }
                                     // Insert new gpm mapping at new address
-                                    gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                    guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                         new_vaddr_aligned as GuestPhysAddr,
                                         paddr as HostPhysAddr,
                                         bar_size as _,
@@ -1543,7 +1543,7 @@ fn handle_pci_bridge_access(
                                 {
                                     // warn!("delete rom bar: can not found 0x{:x}", old_vaddr);
                                 }
-                                gpm.try_insert_quiet(MemoryRegion::new_with_offset_mapper(
+                                guard.try_insert_passthrough_region_quiet(MemoryRegion::new_with_offset_mapper(
                                     new_vaddr_aligned as GuestPhysAddr,
                                     paddr as HostPhysAddr,
                                     rom_size as _,
@@ -2104,7 +2104,7 @@ pub fn mmio_vpci_handler_dbi(mmio: &mut MMIOAccess, _base: usize) -> HvResult {
 
             let zone = crate::zone::root_zone();
             let mut inner = zone.write();
-            inner.virtual_pci_mmio_init_delay(&root_config.pci_config, num_pci_bus, domain_id);
+            inner.virtual_pci_mmio_init_delay(&root_config.pci_config, num_pci_bus, domain_id)?;
             drop(inner);
 
             if let Some(domain_cfg) = root_config.pci_config[..num_pci_bus]

--- a/src/pci/vpci_dev/standard.rs
+++ b/src/pci/vpci_dev/standard.rs
@@ -109,7 +109,7 @@ impl VpciDeviceHandler for StandardHandler {
                         bar_size as usize,
                         mmio_vdev_standard_handler,
                         value,
-                    );
+                    )?;
                 }
 
                 Ok(PciConfigAccessStatus::Done(value))

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -285,7 +285,9 @@ impl ZoneInner {
     /// Check whether `[start, start+size)` overlaps with any registered MMIO handler region.
     pub fn is_mmio_handler_overlap(&self, start: GuestPhysAddr, size: usize) -> bool {
         let region = MMIORegion { start, size };
-        self.mmio.iter().any(|cfg| cfg.region.is_overlap_with(&region))
+        self.mmio
+            .iter()
+            .any(|cfg| cfg.region.is_overlap_with(&region))
     }
     /// If irq_id belongs to this zone
     pub fn irq_in_zone(&self, irq_id: u32) -> bool {

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -298,10 +298,6 @@ impl ZoneInner {
             .any(|cfg| cfg.region.is_overlap_with(&region))
     }
 
-    /// Insert a passthrough mapping into the stage-2 page table, returning
-    /// `EINVAL` if it overlaps with a registered MMIO handler region. Such an
-    /// overlap would otherwise make the handler unreachable behind a stage-2
-    /// mapping, so it must be rejected rather than silently shadowed.
     pub fn insert_passthrough_region(
         &mut self,
         region: MemoryRegion<GuestPhysAddr>,
@@ -319,10 +315,6 @@ impl ZoneInner {
         self.gpm.insert(region)
     }
 
-    /// Like [`Self::insert_passthrough_region`], but silently ignores a
-    /// stage-2 overlap (mirroring `MemorySet::try_insert_quiet`) so that guest
-    /// BAR writes do not fail on transient re-mapping. The MMIO handler
-    /// cross-check is still enforced.
     pub fn try_insert_passthrough_region_quiet(
         &mut self,
         region: MemoryRegion<GuestPhysAddr>,

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -32,7 +32,7 @@ use crate::config::{HvZoneBootMode, HvZoneConfig, CONFIG_NAME_MAXLEN};
 use crate::cpu_data::{get_cpu_data, this_zone, CpuSet};
 use crate::error::HvResult;
 use crate::memory::addr::GuestPhysAddr;
-use crate::memory::{MMIOConfig, MMIOHandler, MMIORegion, MemorySet};
+use crate::memory::{MMIOConfig, MMIOHandler, MMIORegion, MemoryRegion, MemorySet};
 use core::panic;
 use core::sync::atomic::{AtomicBool, Ordering};
 
@@ -220,7 +220,7 @@ impl ZoneInner {
         size: usize,
         handler: MMIOHandler,
         arg: usize,
-    ) {
+    ) -> HvResult {
         if let Some(mmio) = self.mmio.iter_mut().find(|mmio| mmio.region.start == start) {
             warn!("duplicated mmio region {:#x?}", mmio);
             if mmio.region.size != size {
@@ -228,6 +228,7 @@ impl ZoneInner {
             }
             mmio.handler = handler;
             mmio.arg = arg;
+            Ok(())
         } else {
             let new_region = MMIORegion { start, size };
 
@@ -237,17 +238,23 @@ impl ZoneInner {
                 .iter()
                 .find(|cfg| cfg.region.is_overlap_with(&new_region))
             {
-                panic!(
-                    "New MMIO handler region {:#x?} overlaps with existing handler {:#x?}",
-                    new_region, existing.region
+                return hv_result_err!(
+                    EINVAL,
+                    format!(
+                        "New MMIO handler region {:#x?} overlaps with existing handler {:#x?}",
+                        new_region, existing.region
+                    )
                 );
             }
 
             // Check for overlap with passthrough regions in the stage-2 page table.
             if self.gpm.is_range_overlap(start, size) {
-                panic!(
-                    "New MMIO handler region {:#x?} overlaps with passthrough region in stage-2 page table",
-                    new_region
+                return hv_result_err!(
+                    EINVAL,
+                    format!(
+                        "New MMIO handler region {:#x?} overlaps with passthrough region in stage-2 page table",
+                        new_region
+                    )
                 );
             }
 
@@ -255,7 +262,8 @@ impl ZoneInner {
                 region: new_region,
                 handler,
                 arg,
-            })
+            });
+            Ok(())
         }
     }
     #[allow(dead_code)]
@@ -288,6 +296,48 @@ impl ZoneInner {
         self.mmio
             .iter()
             .any(|cfg| cfg.region.is_overlap_with(&region))
+    }
+
+    /// Insert a passthrough mapping into the stage-2 page table, returning
+    /// `EINVAL` if it overlaps with a registered MMIO handler region. Such an
+    /// overlap would otherwise make the handler unreachable behind a stage-2
+    /// mapping, so it must be rejected rather than silently shadowed.
+    pub fn insert_passthrough_region(
+        &mut self,
+        region: MemoryRegion<GuestPhysAddr>,
+    ) -> HvResult {
+        if self.is_mmio_handler_overlap(region.start, region.size) {
+            return hv_result_err!(
+                EINVAL,
+                format!(
+                    "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                    region.start,
+                    region.start + region.size
+                )
+            );
+        }
+        self.gpm.insert(region)
+    }
+
+    /// Like [`Self::insert_passthrough_region`], but silently ignores a
+    /// stage-2 overlap (mirroring `MemorySet::try_insert_quiet`) so that guest
+    /// BAR writes do not fail on transient re-mapping. The MMIO handler
+    /// cross-check is still enforced.
+    pub fn try_insert_passthrough_region_quiet(
+        &mut self,
+        region: MemoryRegion<GuestPhysAddr>,
+    ) -> HvResult {
+        if self.is_mmio_handler_overlap(region.start, region.size) {
+            return hv_result_err!(
+                EINVAL,
+                format!(
+                    "Passthrough region [{:#x}, {:#x}) overlaps with existing MMIO handler",
+                    region.start,
+                    region.start + region.size
+                )
+            );
+        }
+        self.gpm.try_insert_quiet(region)
     }
     /// If irq_id belongs to this zone
     pub fn irq_in_zone(&self, irq_id: u32) -> bool {
@@ -635,7 +685,7 @@ impl ZoneInner {
         &mut self,
         pci_rootcomplex_config: &[HvPciConfig; CONFIG_PCI_BUS_MAXNUM],
         _num_pci_config: usize,
-    ) {
+    ) -> HvResult {
         use crate::memory::mmio_generic_handler;
         use crate::pci::pci_handler::mmio_vpci_handler_dbi;
         use crate::platform;
@@ -652,7 +702,7 @@ impl ZoneInner {
                 rootcomplex_config.ecam_size as usize,
                 mmio_vpci_handler_dbi,
                 encoded_arg,
-            );
+            )?;
 
             let extend_config = platform::ROOT_DWC_ATU_CONFIG
                 .iter()
@@ -664,10 +714,11 @@ impl ZoneInner {
                         extend_config.apb_size as usize,
                         mmio_generic_handler,
                         extend_config.apb_base as usize,
-                    );
+                    )?;
                 }
             }
         }
+        Ok(())
     }
 
     #[cfg(all(pci_init_delay, dwc_pcie))]
@@ -676,7 +727,7 @@ impl ZoneInner {
         pci_rootcomplex_config: &[HvPciConfig; CONFIG_PCI_BUS_MAXNUM],
         _num_pci_config: usize,
         domain_id: u8,
-    ) {
+    ) -> HvResult {
         #[cfg(loongarch64_pcie)]
         let mut emergency_map_regions: alloc::vec::Vec<(usize, usize)> = alloc::vec::Vec::new();
 
@@ -693,7 +744,7 @@ impl ZoneInner {
                     rootcomplex_config.ecam_size as usize,
                     mmio_vpci_handler,
                     rootcomplex_config.ecam_base as usize,
-                );
+                )?;
             }
             #[cfg(dwc_pcie)]
             {
@@ -712,7 +763,7 @@ impl ZoneInner {
                     rootcomplex_config.ecam_size as usize,
                     mmio_vpci_handler_dbi,
                     encoded_arg,
-                );
+                )?;
 
                 let extend_config = platform::ROOT_DWC_ATU_CONFIG
                     .iter()
@@ -725,7 +776,7 @@ impl ZoneInner {
                             extend_config.apb_size as usize,
                             mmio_generic_handler,
                             extend_config.apb_base as usize,
-                        );
+                        )?;
                     }
 
                     let cfg_size_half = extend_config.cfg_size / 2;
@@ -736,7 +787,7 @@ impl ZoneInner {
                             cfg_size_half as usize,
                             mmio_dwc_cfg_handler,
                             cfg0_base as usize,
-                        );
+                        )?;
                     }
 
                     let cfg1_base = extend_config.cfg_base + cfg_size_half;
@@ -746,7 +797,7 @@ impl ZoneInner {
                             cfg_size_half as usize,
                             mmio_dwc_cfg_handler,
                             cfg1_base as usize,
-                        );
+                        )?;
                     }
 
                     if extend_config.io_cfg_atu_shared != 0 {
@@ -755,7 +806,7 @@ impl ZoneInner {
                             rootcomplex_config.io_size as usize,
                             mmio_dwc_io_handler,
                             rootcomplex_config.io_base as usize,
-                        );
+                        )?;
                     }
 
                     let mut atu = AtuConfig::default();
@@ -793,7 +844,7 @@ impl ZoneInner {
                     rootcomplex_config.ecam_size as usize,
                     mmio_vpci_direct_handler,
                     rootcomplex_config.ecam_base as usize,
-                );
+                )?;
                 emergency_map_regions.push((
                     rootcomplex_config.ecam_base as usize,
                     rootcomplex_config.ecam_size as usize,
@@ -807,6 +858,8 @@ impl ZoneInner {
                 );
             }
         }
+
+        Ok(())
 
         // Note: emergency_map_regions requires access to self (for Zone), so this must be handled at Zone level
     }
@@ -902,7 +955,7 @@ pub fn zone_create(config: &HvZoneConfig) -> HvResult<Arc<Zone>> {
 
     let mut zone = Zone::new(zone_id, &config.name);
     zone.pt_init(config.memory_regions())?;
-    zone.mmio_init(&config.arch_config);
+    zone.mmio_init(&config.arch_config)?;
 
     let mut cpu_num = 0;
     for (guest_cpu, cpu_id) in config.cpus().iter().enumerate() {
@@ -935,9 +988,9 @@ pub fn zone_create(config: &HvZoneConfig) -> HvResult<Arc<Zone>> {
                 let num_pci_bus = config.num_pci_bus as usize;
                 if zone_id == 0 {
                     let mut inner = zone.write();
-                    inner.virtual_pci_dbi_pref_init(&config.pci_config, num_pci_bus);
+                    inner.virtual_pci_dbi_pref_init(&config.pci_config, num_pci_bus)?;
                 } else {
-                    let _ = zone.virtual_pci_mmio_init(&config.pci_config, num_pci_bus);
+                    zone.virtual_pci_mmio_init(&config.pci_config, num_pci_bus)?;
                     let _ = zone.guest_pci_init(
                         zone_id,
                         &config.alloc_pci_devs,
@@ -951,7 +1004,7 @@ pub fn zone_create(config: &HvZoneConfig) -> HvResult<Arc<Zone>> {
 
         #[cfg(not(pci_init_delay))]
         {
-            let _ = zone.virtual_pci_mmio_init(&config.pci_config, config.num_pci_bus as usize);
+            zone.virtual_pci_mmio_init(&config.pci_config, config.num_pci_bus as usize)?;
             let _ = zone.guest_pci_init(
                 zone_id,
                 &config.alloc_pci_devs,
@@ -967,7 +1020,7 @@ pub fn zone_create(config: &HvZoneConfig) -> HvResult<Arc<Zone>> {
         use crate::platform::{IOMMU_SYS_BASE, IOMMU_SYS_SIZE};
         // Create viommu instance and register mmio handler for target zone.
         crate::device::iommu::viommu_init(zone_id);
-        crate::device::iommu::viommu_mmio_handler_register(&zone, IOMMU_SYS_BASE, IOMMU_SYS_SIZE);
+        crate::device::iommu::viommu_mmio_handler_register(&zone, IOMMU_SYS_BASE, IOMMU_SYS_SIZE)?;
     }
 
     // #[cfg(target_arch = "aarch64")]

--- a/src/zone.rs
+++ b/src/zone.rs
@@ -229,8 +229,30 @@ impl ZoneInner {
             mmio.handler = handler;
             mmio.arg = arg;
         } else {
+            let new_region = MMIORegion { start, size };
+
+            // Check for overlap with existing mmio handler regions.
+            if let Some(existing) = self
+                .mmio
+                .iter()
+                .find(|cfg| cfg.region.is_overlap_with(&new_region))
+            {
+                panic!(
+                    "New MMIO handler region {:#x?} overlaps with existing handler {:#x?}",
+                    new_region, existing.region
+                );
+            }
+
+            // Check for overlap with passthrough regions in the stage-2 page table.
+            if self.gpm.is_range_overlap(start, size) {
+                panic!(
+                    "New MMIO handler region {:#x?} overlaps with passthrough region in stage-2 page table",
+                    new_region
+                );
+            }
+
             self.mmio.push(MMIOConfig {
-                region: MMIORegion { start, size },
+                region: new_region,
                 handler,
                 arg,
             })
@@ -258,6 +280,12 @@ impl ZoneInner {
             .iter()
             .find(|cfg| cfg.region.contains_region(addr, size))
             .map(|cfg| (cfg.region, cfg.handler, cfg.arg))
+    }
+
+    /// Check whether `[start, start+size)` overlaps with any registered MMIO handler region.
+    pub fn is_mmio_handler_overlap(&self, start: GuestPhysAddr, size: usize) -> bool {
+        let region = MMIORegion { start, size };
+        self.mmio.iter().any(|cfg| cfg.region.is_overlap_with(&region))
     }
     /// If irq_id belongs to this zone
     pub fn irq_in_zone(&self, irq_id: u32) -> bool {


### PR DESCRIPTION
### Summary

MMIO passthrough regions (MEM_TYPE_IO, mapped in stage-2 page table) and MMIO intercept handler regions (registered via `mmio_region_register()`) have no cross-overlap validation. If both occupy overlapping GPA ranges, the handler silently becomes dead code — the stage-2 mapping prevents any fault, so the handler is never invoked.

### Background

hvisor uses two mechanisms for guest MMIO:

| Mechanism | Registration | Behavior |
|-----------|-------------|----------|
| Passthrough | `pt_init()` → `gpm.insert()` | Direct hardware access, no stage-2 fault |
| Intercept | `mmio_region_register()` → `ZoneInner.mmio` | Stage-2 fault triggers handler |

Each mechanism checks overlaps internally (gpm checks gpm-vs-gpm; mmio checks exact start-address duplicates), but **no cross-check exists between them**. The zone creation flow processes them independently:

```
zone_create()
  pt_init()      → gpm.insert()          (checks gpm-vs-gpm only)
  mmio_init()    → mmio_region_register() (checks exact duplicate only)
  PCI init       → mmio_region_register() (checks exact duplicate only)
```

### Fix

Added bidirectional overlap checks at two insertion points:

**1. `mmio_region_register()` (src/zone.rs)** — When registering a new intercept handler, panic if:
- It overlaps with any existing MMIO handler region (not just exact duplicates).
- It overlaps with any passthrough region already in the stage-2 page table.

**2. `pt_init()` (all four architectures)** — Before inserting a passthrough region into gpm, check whether it overlaps with any already-registered MMIO handler. Overlap triggers a panic.

New utility methods:
- `MMIORegion::is_overlap_with()` in src/memory/mmio.rs — range overlap test
- `MemorySet::is_range_overlap()` in src/memory/mm.rs — public O(log n) query against stage-2 mappings
- `ZoneInner::is_mmio_handler_overlap()` in src/zone.rs — helper for pt_init checks

On loongarch64, the VIRTIO branch in `pt_init()` was reordered (`mmio_region_register` before `gpm.insert`) to avoid a false positive from the VIRTIO trap page.

### Coverage

| Scenario | Caught by |
|----------|-----------|
| Two intercept handler regions overlap | `mmio_region_register()` handler-vs-handler |
| Passthrough inserted before intercept handler | `mmio_region_register()` handler-vs-gpm |
| Intercept handler registered before passthrough | `pt_init()` gpm-vs-handler |
| Same loop: IO entry before VIRTIO entry | `mmio_region_register()` handler-vs-gpm |
| Same loop: VIRTIO entry before IO entry | `pt_init()` gpm-vs-handler |

### Files Changed

- `src/memory/mmio.rs` — add `MMIORegion::is_overlap_with()`
- `src/memory/mm.rs` — add `MemorySet::is_range_overlap()`
- `src/zone.rs` — add checks in `mmio_region_register()` + `is_mmio_handler_overlap()` helper
- `src/arch/x86_64/zone.rs` — add handler overlap check before `gpm.insert()`
- `src/arch/aarch64/zone.rs` — same
- `src/arch/riscv64/zone.rs` — same
- `src/arch/loongarch64/zone.rs` — same + swap VIRTIO order

### Verification

Tested on x86_64 QEMU by adding a VIRTIO region at the same address as the HPET IO passthrough (0xfed0_0000). The fix correctly panics at zone creation:

```
New MMIO handler region MMIORegion { start: 0xfed00000, size: 0x1000 }
overlaps with passthrough region in stage-2 page table
```

All four architectures (x86_64, aarch64, riscv64, loongarch64) compile successfully.
