### PR TITLE
fix(x86_64): restrict guest-controlled interrupt destinations to the owning zone

### DIFF
--- a/src/arch/x86_64/acpi.rs
+++ b/src/arch/x86_64/acpi.rs
@@ -714,6 +714,12 @@ pub fn get_cpu_id(apic_id: usize) -> usize {
         .unwrap()
 }
 
+/// Like [`get_cpu_id`], but returns `None` for an APIC ID the firmware never
+/// reported instead of panicking. Use this for guest-supplied APIC IDs.
+pub fn try_get_cpu_id(apic_id: usize) -> Option<usize> {
+    ROOT_ACPI.get()?.apic_id_to_cpu_id.get(&apic_id).copied()
+}
+
 pub fn get_apic_id(cpu_id: usize) -> usize {
     *ROOT_ACPI
         .get()

--- a/src/arch/x86_64/ipi.rs
+++ b/src/arch/x86_64/ipi.rs
@@ -16,7 +16,7 @@
 
 use crate::{
     arch::{
-        acpi::{get_apic_id, get_cpu_id},
+        acpi::{get_apic_id, try_get_cpu_id},
         cpu::this_cpu_id,
         idt::IdtVector,
     },
@@ -88,8 +88,6 @@ pub fn send_ipi(value: u64) -> HvResult {
     let vector = value.get_bits(0..=7) as u8;
     let delivery_mode: u8 = value.get_bits(8..=10) as u8;
     let dest_shorthand = value.get_bits(18..=19) as u8;
-    let dest = get_cpu_id(value.get_bits(32..=39) as usize);
-    let cnt = value.get_bits(40..=63) as u32;
 
     let mut cpu_set = this_zone().cpu_set();
     let cpu_id = this_cpu_id();
@@ -97,7 +95,18 @@ pub fn send_ipi(value: u64) -> HvResult {
 
     match dest_shorthand {
         IpiDestShorthand::NO_SHORTHAND => {
-            dest_set.set_bit(dest);
+            // x2APIC carries the full 32-bit destination APIC ID in bits 32..=63.
+            // Only physical destination mode (bit 11 clear) is modelled; resolve
+            // the id fallibly and deliver only to a CPU in this zone. A logical
+            // destination mask, or an unknown or out-of-zone id, is dropped, so an
+            // IPI can neither panic on a bogus id nor reach a CPU in another zone.
+            if !value.get_bit(11) {
+                if let Some(dest) = try_get_cpu_id(value.get_bits(32..=63) as usize) {
+                    if cpu_set.contains_cpu(dest) {
+                        dest_set.set_bit(dest);
+                    }
+                }
+            }
         }
         IpiDestShorthand::SELF => {
             dest_set.set_bit(cpu_id);

--- a/src/arch/x86_64/trap.rs
+++ b/src/arch/x86_64/trap.rs
@@ -28,10 +28,7 @@ use crate::{
     },
     cpu_data::{this_cpu_data, this_zone},
     device::{
-        irqchip::{
-            inject_vector,
-            pic::{ioapic::irqs, lapic::VirtLocalApic},
-        },
+        irqchip::{inject_vector, pic::lapic::VirtLocalApic},
         uart::{virt_console_io_read, virt_console_io_write, UartReg},
     },
     error::HvResult,

--- a/src/device/irqchip/pic/ioapic.rs
+++ b/src/device/irqchip/pic/ioapic.rs
@@ -16,28 +16,24 @@
 
 use crate::{
     arch::{
-        acpi::{get_apic_id, get_cpu_id},
-        cpu::this_cpu_id,
-        idt, ipi,
-        mmio::MMIoDevice,
+        acpi::try_get_cpu_id,
+        cpu::{this_apic_id, this_cpu_id},
+        idt::IdtVector,
         zone::HvArchZoneConfig,
     },
+    cpu_data::this_zone,
     device::irqchip::pic::inject_vector,
     error::HvResult,
     memory::{GuestPhysAddr, MMIOAccess},
     platform::ROOT_ZONE_IOAPIC_BASE,
-    zone::{this_zone_id, Zone},
+    zone::{find_zone, this_zone_id, Zone},
 };
-use alloc::{sync::Arc, vec::Vec};
+use alloc::vec::Vec;
 use bit_field::BitField;
-use core::{ops::Range, u32};
+use core::u32;
 use spin::{Mutex, Once};
 use x2apic::ioapic::IoApic;
 use x86_64::instructions::port::Port;
-
-pub mod irqs {
-    pub const UART_COM1_IRQ: u8 = 0x4;
-}
 
 #[allow(non_snake_case)]
 pub mod IoApicReg {
@@ -85,15 +81,20 @@ impl VirtIoApic {
         if gpa == 0 {
             return Ok(ioapic.lock().cur_reg as _);
         }
-        assert!(gpa == 0x10);
+        // Other offsets within the registered MMIO page are not modelled; read
+        // them as zero rather than faulting the hypervisor.
+        if gpa != 0x10 {
+            return Ok(0);
+        }
 
         let inner = ioapic.lock();
         match inner.cur_reg {
             IoApicReg::ID => Ok(0),
             IoApicReg::VERSION => Ok(IOAPIC_MAX_REDIRECT_ENTRIES << 16 | 0x11), // max redirect entries: 0x17, version: 0x11
             IoApicReg::ARBITRATION => Ok(0),
-            mut reg => {
-                reg -= IoApicReg::TABLE_BASE;
+            reg if reg < IoApicReg::TABLE_BASE => Ok(0),
+            reg => {
+                let reg = reg - IoApicReg::TABLE_BASE;
                 let index = (reg >> 1) as usize;
                 if let Some(entry) = inner.rte.get(index) {
                     if reg % 2 == 0 {
@@ -108,10 +109,10 @@ impl VirtIoApic {
         }
     }
 
-    fn write(&self, gpa: GuestPhysAddr, value: u64, size: usize) -> HvResult {
+    fn write(&self, gpa: GuestPhysAddr, value: u64, _size: usize) -> HvResult {
         /*info!(
             "ioapic write! gpa: {:x}, value: {:x}, size: {:x}",
-            gpa, value, size,
+            gpa, value, _size,
         );*/
 
         let zone_id = this_zone_id();
@@ -120,26 +121,69 @@ impl VirtIoApic {
             ioapic.lock().cur_reg = value as _;
             return Ok(());
         }
-        assert!(gpa == 0x10);
+        // Other offsets within the registered MMIO page are not modelled; ignore.
+        if gpa != 0x10 {
+            return Ok(());
+        }
 
         let mut inner = ioapic.lock();
         match inner.cur_reg {
-            IoApicReg::ID | IoApicReg::VERSION | IoApicReg::ARBITRATION => {}
-            mut reg => {
-                reg -= IoApicReg::TABLE_BASE;
+            // ID / VERSION / ARBITRATION and any other non-table register: ignore.
+            reg if reg < IoApicReg::TABLE_BASE => {}
+            reg => {
+                let reg = reg - IoApicReg::TABLE_BASE;
                 let index = (reg >> 1) as usize;
                 if let Some(entry) = inner.rte.get_mut(index) {
                     if reg % 2 == 0 {
                         entry.set_bits(0..=31, value.get_bits(0..=31));
                     } else {
                         entry.set_bits(32..=63, value.get_bits(0..=31));
-
-                        /*if zone_id == 0 {
-                            // info!("1 write {:x} entry: {:x?}", index, *entry);
-                            // only root zone modify the real I/O APIC
-                            // unsafe { configure_gsi_from_raw(index as _, *entry) };
-                        }*/
                     }
+
+                    // hvisor does not model logical delivery, and the root zone
+                    // mirrors this entry into the real I/O APIC, so a logical or
+                    // out-of-zone destination must not survive. Re-evaluate after
+                    // every dword write (mode and destination may be written in
+                    // either order) and force the entry into physical mode with a
+                    // destination CPU owned by this zone unless it already is one;
+                    // neither software injection nor real hardware can then target
+                    // a CPU outside the zone.
+                    let requested = entry.get_bits(56..=63) as usize;
+                    let in_zone_physical = !entry.get_bit(11)
+                        && try_get_cpu_id(requested)
+                            .map_or(false, |cpu| this_zone().cpu_set().contains_cpu(cpu));
+                    if !in_zone_physical {
+                        entry.set_bit(11, false); // physical destination mode
+                        entry.set_bits(56..=63, this_apic_id() as u64);
+                    }
+
+                    // The root zone mirrors this entry into the real I/O APIC, so the
+                    // delivery semantics must be sanitised too, not just the
+                    // destination: force Fixed delivery (bits 8..=10) so a guest
+                    // cannot raise NMI/INIT/ExtINT on a physical CPU, clear the
+                    // reserved bits, and mask any entry whose vector is below the
+                    // first valid IRQ vector (0x20) so it cannot collide with a CPU
+                    // exception vector. The same sanitised entry is what software
+                    // injection reads back, keeping both delivery paths in agreement.
+                    entry.set_bits(8..=10, 0);
+                    entry.set_bits(17..=55, 0);
+                    // Mask the entry if its vector is invalid (below the first IRQ
+                    // vector) or collides with a vector hvisor reserves for its own
+                    // use on the physical CPUs: a guest device firing on the virtual
+                    // IPI / APIC error / spurious / timer vector would otherwise be
+                    // taken by the host IDT and drive hypervisor interrupt handling.
+                    let vector = entry.get_bits(0..=7) as u8;
+                    let reserved = matches!(
+                        vector,
+                        IdtVector::VIRT_IPI_VECTOR
+                            | IdtVector::APIC_ERROR_VECTOR
+                            | IdtVector::APIC_SPURIOUS_VECTOR
+                            | IdtVector::APIC_TIMER_VECTOR
+                    );
+                    if vector < 0x20 || reserved {
+                        entry.set_bit(16, true);
+                    }
+
                     if zone_id == 0 {
                         // only root zone modify the real I/O APIC
                         unsafe { configure_gsi_from_raw(index as _, *entry) };
@@ -151,24 +195,30 @@ impl VirtIoApic {
     }
 
     fn get_irq_cpu(&self, irq: usize, zone_id: usize) -> Option<usize> {
-        let ioapic = self.inner.get(zone_id).unwrap();
-        if let Some(entry) = ioapic.lock().rte.get(irq) {
-            let dest = get_cpu_id(entry.get_bits(56..=63) as usize);
-            return Some(dest);
-        }
-        None
+        // A written entry is clamped to an in-zone destination, but an entry that
+        // was never programmed defaults to APIC id 0, so confirm the resolved CPU
+        // actually belongs to the target zone before trusting it.
+        let entry = *self.inner.get(zone_id).unwrap().lock().rte.get(irq)?;
+        let cpu = try_get_cpu_id(entry.get_bits(56..=63) as usize)?;
+        find_zone(zone_id)?
+            .cpu_set()
+            .contains_cpu(cpu)
+            .then_some(cpu)
     }
 
     fn trigger(&self, irq: usize, allow_repeat: bool) -> HvResult {
         let zone_id = this_zone_id();
         let ioapic = self.inner.get(zone_id).unwrap();
         if let Some(entry) = ioapic.lock().rte.get(irq) {
-            // TODO: physical & logical mode
-            let dest = get_cpu_id(entry.get_bits(56..=63) as usize);
             let masked = entry.get_bit(16);
             let vector = entry.get_bits(0..=7) as u8;
-            // info!("trigger hv: {:x} zone: {:x}", vector, zone_id);
             if !masked && vector >= 0x20 {
+                // Deliver only to a CPU this zone owns: a written entry is clamped
+                // in-zone, but an unprogrammed entry resolves to APIC 0, so filter
+                // by zone membership and otherwise use the current (in-zone) CPU.
+                let dest = try_get_cpu_id(entry.get_bits(56..=63) as usize)
+                    .filter(|&cpu| this_zone().cpu_set().contains_cpu(cpu))
+                    .unwrap_or_else(this_cpu_id);
                 inject_vector(dest, vector, None, allow_repeat);
             }
         }
@@ -197,7 +247,7 @@ fn mmio_ioapic_handler(mmio: &mut MMIOAccess, _: usize) -> HvResult {
             .unwrap()
             .write(mmio.address, mmio.value as _, mmio.size)
     } else {
-        mmio.value = VIRT_IOAPIC.get().unwrap().read(mmio.address).unwrap() as _;
+        mmio.value = VIRT_IOAPIC.get().unwrap().read(mmio.address)? as _;
         Ok(())
     }
 }
@@ -221,13 +271,17 @@ pub fn init_virt_ioapic(max_zones: usize) {
 }
 
 pub fn ioapic_inject_irq(irq: u8, allow_repeat: bool) {
-    VIRT_IOAPIC.get().unwrap().trigger(irq as _, allow_repeat);
+    let _ = VIRT_IOAPIC.get().unwrap().trigger(irq as _, allow_repeat);
 }
 
 pub fn get_irq_cpu(irq: usize, zone_id: usize) -> usize {
+    // If the redirection entry has no resolvable in-zone destination (e.g. a
+    // logical-mode mask), fall back to the target zone's first CPU so routing
+    // stays inside the zone and never panics on a guest-controlled value.
     VIRT_IOAPIC
         .get()
         .unwrap()
         .get_irq_cpu(irq, zone_id)
-        .unwrap()
+        .or_else(|| find_zone(zone_id).and_then(|z| z.cpu_set().first_cpu()))
+        .unwrap_or(0)
 }

--- a/src/device/irqchip/pic/lapic.rs
+++ b/src/device/irqchip/pic/lapic.rs
@@ -24,7 +24,6 @@ use crate::{
     cpu_data::this_cpu_data,
     device::irqchip::pic::pop_vector,
     error::HvResult,
-    memory::Frame,
 };
 use bit_field::BitField;
 use core::{ops::Range, u32};
@@ -102,8 +101,7 @@ impl VirtLocalApic {
             }
             IA32_X2APIC_ICR => {
                 // info!("ICR value: {:x}", value);
-                ipi::send_ipi(value);
-                Ok(())
+                ipi::send_ipi(value)
             }
             IA32_X2APIC_LVT_TIMER => {
                 self.virt_lvt_timer_bits = value as u32;


### PR DESCRIPTION
This is the one worth actually flagging for review — it's a zone-isolation
gap, not just a correctness nit.

Both interrupt-injection paths a guest can drive — the virtual x2APIC's ICR
write (for sending IPIs) and the virtual IOAPIC's redirection-table-entry
writes — take a destination APIC id straight from guest-controlled data
and resolve it with `get_cpu_id()` with no check that the resulting CPU is
actually inside the zone doing the writing. So a guest can aim an IPI or
route a device interrupt at a CPU running a *different* zone. And if the
APIC id doesn't resolve to anything real, `get_cpu_id()` just panics — so a
guest can crash the whole hypervisor by writing a bogus id.

Added `try_get_cpu_id()` in `acpi.rs` — same lookup, returns `None` instead
of panicking. Used it everywhere a guest-controlled APIC id gets resolved:

- `send_ipi()` in `ipi.rs`: only delivers a physical-mode, no-shorthand IPI
  (x2APIC logical destination mode isn't modeled and gets dropped) to a CPU
  that's actually in the sending zone's `cpu_set`. Anything else just gets
  silently dropped instead of crossing zones or panicking.
- `VirtIoApic::write()` in `ioapic.rs`: every RTE write gets re-sanitized
  (has to be — mode and destination can arrive as separate dword writes in
  either order) — destination clamped into the writing zone unless it
  already resolves there, delivery mode bits zeroed so a guest can't
  request NMI/INIT/ExtINT on the real IOAPIC entry this mirrors into, and
  the entry gets masked outright if its vector collides with a reserved
  hvisor vector (VIRT_IPI/APIC_ERROR/APIC_SPURIOUS/APIC_TIMER) or falls
  below the first valid IRQ vector.
- `get_irq_cpu()`/`trigger()` now re-derive the destination from the
  already-sanitized entry instead of trusting whatever was last written,
  and don't panic if it somehow still doesn't resolve — fall back to the
  zone's first CPU / the current CPU respectively.

Dropped an unused `UART_COM1_IRQ` constant and an unused import while in
the file, unrelated cleanup.

`make ARCH=x86_64 BOARD=qemu MODE=release all` and
`cargo fmt --all -- --check`, both clean.