### PR TITLE
feat(x86_64): boot Asterinas root zone

### DIFF
--- a/src/arch/x86_64/acpi.rs
+++ b/src/arch/x86_64/acpi.rs
@@ -714,6 +714,13 @@ pub fn get_cpu_id(apic_id: usize) -> usize {
         .unwrap()
 }
 
+/// Non-panicking variant of [`get_cpu_id`]: returns `None` when `apic_id` is not
+/// a known local-APIC id. Use this on any path that consumes a guest-supplied
+/// APIC id, so a malicious or buggy guest cannot panic the hypervisor.
+pub fn try_get_cpu_id(apic_id: usize) -> Option<usize> {
+    ROOT_ACPI.get()?.apic_id_to_cpu_id.get(&apic_id).copied()
+}
+
 pub fn get_apic_id(cpu_id: usize) -> usize {
     *ROOT_ACPI
         .get()

--- a/src/arch/x86_64/boot.rs
+++ b/src/arch/x86_64/boot.rs
@@ -26,7 +26,6 @@ use alloc::string::{String, ToString};
 use bit_field::BitField;
 use core::{
     arch::{self, global_asm},
-    ffi::{c_char, CStr},
     mem::size_of,
     ptr::{copy, copy_nonoverlapping},
 };
@@ -320,6 +319,15 @@ impl BootParams {
         cnt
     }
 
+    /// Hand the guest its initramfs through the boot-params ramdisk fields.
+    ///
+    /// The ramdisk lives inside a RAM `memory_region`, so it is reported as
+    /// usable RAM in the e820/EFI map; the guest learns to keep it intact from
+    /// `ramdisk_image`/`ramdisk_size` here (Linux and Asterinas both reserve
+    /// `[ramdisk_image, ramdisk_image + ramdisk_size)` before populating the
+    /// frame allocator), which is why it is not separately carved out of e820.
+    /// `ramdisk_size` must be the true byte length of the image that is staged
+    /// at `ramdisk_image`; an undersized value truncates the archive.
     fn set_initrd(&mut self, ramdisk_image: u32, ramdisk_size: u32) {
         self.ramdisk_image = ramdisk_image;
         self.ramdisk_size = ramdisk_size;
@@ -534,50 +542,248 @@ pub fn print_memory_map() {
     }
 }
 
-/// copy kernel modules to the right place
+/// Maximum number of multiboot2 modules relocated during early boot.
+const MAX_BOOT_MODULES: usize = 16;
+
+#[derive(Clone, Copy)]
+struct BootModule {
+    /// Address where the bootloader staged the module image.
+    src: usize,
+    /// One past the last staged byte (`src + len`, computed with checked
+    /// arithmetic so a bogus descriptor cannot wrap a range used in overlap
+    /// tests).
+    src_end: usize,
+    /// Number of bytes occupied by the staged image.
+    len: usize,
+    /// Guest-physical address the module is relocated to, or 0 when the module
+    /// is consumed in place and left where the bootloader staged it.
+    dst: usize,
+    /// One past the last destination byte (`dst + len`, checked), or 0 when the
+    /// module is consumed in place.
+    dst_end: usize,
+}
+
+/// Relocate the multiboot2 modules supplied by the bootloader to the load
+/// addresses encoded in each module's command-line string.
+///
+/// A guest may be delivered as several modules (for example a multiboot2
+/// Asterinas image alongside its initramfs), and the bootloader is free to
+/// stage them anywhere in low memory. The destination of one module can
+/// therefore overlap the staging area of another module that has not been
+/// copied yet, so the relocations are ordered such that a module is only moved
+/// once no pending module is still sourced from its destination range. The
+/// copy itself is a memmove, which keeps a module that overlaps its own
+/// destination correct.
+///
+/// The ordering relocates any *acyclic* layout. A genuine cycle (module A's
+/// destination overlaps module B's source while B's destination overlaps A's
+/// source) cannot be satisfied in place and is *reported* (panic), not resolved
+/// with a scratch buffer; likewise overlapping final destinations and range
+/// arithmetic that would wrap are rejected. This is containment, not silent
+/// corruption: no layout is ever copied incorrectly.
 pub fn module_init(info_addr: usize) {
-    println!("module_init");
-    let mut cur = info_addr;
-    let total_size = unsafe { *(cur as *const u32) } as usize;
+    let total_size = unsafe { *(info_addr as *const u32) } as usize;
 
-    let mut cnt = 0;
-    cur += 8;
-    while cur < info_addr + total_size {
+    let mut modules = [BootModule {
+        src: 0,
+        src_end: 0,
+        len: 0,
+        dst: 0,
+        dst_end: 0,
+    }; MAX_BOOT_MODULES];
+    let mut count = 0;
+
+    // The multiboot2 information block is an 8-byte header followed by
+    // 8-byte-aligned tags. Bound every read to the declared size and reject
+    // malformed tags so a garbage/hostile bootloader cannot make the walk read
+    // out of bounds or spin on a non-advancing tag.
+    let info_end = info_addr
+        .checked_add(total_size)
+        .expect("module_init: multiboot2 info size overflows the address space");
+    let mut cur = info_addr + 8;
+    // Short-circuit on `cur < info_end` *before* the subtraction: if
+    // `total_size < 8` then `info_end < cur`, so `info_end - cur` would
+    // underflow (unsigned) to a huge value and spin the loop reading out of
+    // bounds. Guarding on `cur < info_end` first makes the subtraction safe and
+    // correctly skips the loop for an undersized info block.
+    while cur < info_end && info_end - cur >= 8 {
         let tag_type = unsafe { *(cur as *const u32) };
-        let ptr = cur as *const multiboot_tag::Modules;
-        cur += ((unsafe { *((cur + 4) as *const u32) } as usize + 7) & (!7));
-
+        let tag_size = unsafe { *((cur + 4) as *const u32) } as usize;
         if tag_type == multiboot_tag::END {
             break;
         }
-        if tag_type != multiboot_tag::MODULES {
-            continue;
+        // Every tag is at least its 8-byte header and must lie within the block.
+        if tag_size < 8 || tag_size > info_end - cur {
+            panic!(
+                "module_init: malformed multiboot2 tag (type {}, size {})",
+                tag_type, tag_size
+            );
         }
-
-        let module = unsafe { *ptr };
-        let dst = unsafe {
-            usize::from_str_radix(
-                CStr::from_ptr(((ptr as usize) + size_of::<Modules>()) as *const c_char)
-                    .to_str()
-                    .unwrap(),
-                16,
-            )
-            .unwrap()
-        };
-        println!("module: {:#x?}, addr: {:#x?}", module, dst);
-        cnt += 1;
-
-        if dst == 0x0 {
-            continue;
+        if tag_type == multiboot_tag::MODULES {
+            let hdr = size_of::<Modules>();
+            if tag_size <= hdr {
+                panic!("module_init: MODULES tag is too small for a command line");
+            }
+            // The module command line carries the load destination as a hex
+            // physical address (optionally followed by arguments). Search for the
+            // NUL terminator *within the tag bounds* rather than trusting
+            // termination, and check every parse step rather than unwrapping
+            // blind, so bad bootloader data fails loudly instead of corrupting
+            // memory or reading past the tag.
+            let str_bytes =
+                unsafe { core::slice::from_raw_parts((cur + hdr) as *const u8, tag_size - hdr) };
+            let nul = str_bytes
+                .iter()
+                .position(|&b| b == 0)
+                .expect("module_init: module command line is not NUL-terminated within its tag");
+            let s = core::str::from_utf8(&str_bytes[..nul])
+                .expect("module_init: module command line is not valid UTF-8");
+            let first = s
+                .trim()
+                .split_whitespace()
+                .next()
+                .expect("module_init: empty module command line (expected a hex load address)");
+            let dst = usize::from_str_radix(first, 16)
+                .expect("module_init: module load address is not a hex number");
+            let tag = unsafe { &*(cur as *const Modules) };
+            // multiboot2 `mod_end` is the address one past the module's last
+            // byte (exclusive), so the length is `mod_end - mod_start`. The
+            // exclusive range ends are pre-computed with checked arithmetic so a
+            // descriptor near the top of the address space cannot wrap a value
+            // the overlap/scheduler tests below rely on.
+            let src = tag.mod_start as usize;
+            let len = (tag.mod_end as usize)
+                .checked_sub(src)
+                .expect("module_init: multiboot2 module has mod_end < mod_start");
+            // An empty module (mod_end == mod_start) carries no data and
+            // occupies no bytes, so it is ignored: it is never added to the
+            // modules array (and never counted), which keeps the half-open
+            // overlap predicates from misfiring on a zero-length range and
+            // raising a spurious overlapping-load / cyclic-overlap panic.
+            if len == 0 {
+                cur += (tag_size + 7) & !7;
+                continue;
+            }
+            let src_end = src
+                .checked_add(len)
+                .expect("module_init: module source range overflows the address space");
+            let dst_end = if dst == 0 {
+                0
+            } else {
+                dst.checked_add(len)
+                    .expect("module_init: module destination range overflows the address space")
+            };
+            if count == MAX_BOOT_MODULES {
+                panic!(
+                    "module_init: more than {} multiboot2 modules; raise MAX_BOOT_MODULES",
+                    MAX_BOOT_MODULES
+                );
+            }
+            modules[count] = BootModule {
+                src,
+                src_end,
+                len,
+                dst,
+                dst_end,
+            };
+            count += 1;
         }
-
-        unsafe {
-            core::ptr::copy(
-                module.mod_start as *mut u8,
-                dst as *mut u8,
-                (module.mod_end - module.mod_start + 1) as usize,
-            )
-        };
+        // tag_size >= 8 guarantees forward progress; the END tag terminates the
+        // walk, and the loop condition keeps the aligned advance in bounds.
+        cur += (tag_size + 7) & !7;
     }
-    println!("module cnt: {:x}", cnt);
+
+    // The relocation scheduler below only protects module *sources* from being
+    // clobbered before they are copied; it does not prevent two modules from
+    // being copied onto overlapping *destinations*, which would deterministically
+    // corrupt one of the final images. Reject that pathological layout up front.
+    // Destination arithmetic is checked so a bogus mod_end cannot wrap a range.
+    for i in 0..count {
+        if modules[i].dst == 0 {
+            continue;
+        }
+        for j in (i + 1)..count {
+            if modules[j].dst == 0 {
+                continue;
+            }
+            // Half-open interval overlap on the pre-checked destination ranges.
+            if modules[i].dst < modules[j].dst_end && modules[i].dst_end > modules[j].dst {
+                panic!("module_init: modules have overlapping load destinations");
+            }
+        }
+    }
+
+    let mut relocated = [false; MAX_BOOT_MODULES];
+    let mut copied = 0usize;
+    let mut in_place = 0usize;
+    let mut remaining = count;
+    while remaining > 0 {
+        let mut progress = false;
+        for i in 0..count {
+            if relocated[i] {
+                continue;
+            }
+            // A module with no destination is consumed in place; it is never
+            // copied and its staging area must stay intact, so it imposes no
+            // ordering constraint of its own but keeps blocking others below.
+            if modules[i].dst == 0 {
+                relocated[i] = true;
+                remaining -= 1;
+                in_place += 1;
+                progress = true;
+                continue;
+            }
+            let dst = modules[i].dst;
+            let dst_end = modules[i].dst_end;
+            // A module may only be placed once its destination range no longer
+            // overlaps any module that still holds live data at its source: one
+            // that is consumed in place (dst == 0) or not yet relocated. All
+            // endpoints are the pre-checked (non-wrapping) ranges computed above.
+            let blocked = (0..count).any(|j| {
+                j != i
+                    && (modules[j].dst == 0 || !relocated[j])
+                    && dst < modules[j].src_end
+                    && dst_end > modules[j].src
+            });
+            if blocked {
+                continue;
+            }
+            unsafe {
+                copy(modules[i].src as *const u8, dst as *mut u8, modules[i].len);
+            }
+            relocated[i] = true;
+            remaining -= 1;
+            copied += 1;
+            progress = true;
+        }
+        if !progress {
+            // The common real cause of a stall is a not-yet-relocated module
+            // whose destination range overlaps the source range of an in-place
+            // (dst == 0) module, which can never move out of the way. Diagnose
+            // that case specifically before falling back to the generic
+            // cyclic-overlap report.
+            for i in 0..count {
+                if relocated[i] || modules[i].dst == 0 {
+                    continue;
+                }
+                let overlaps_in_place = (0..count).any(|j| {
+                    modules[j].dst == 0
+                        && modules[i].dst < modules[j].src_end
+                        && modules[i].dst_end > modules[j].src
+                });
+                if overlaps_in_place {
+                    panic!(
+                        "module_init: a module destination overlaps an in-place module source \
+                         and cannot relocate onto a module consumed in place"
+                    );
+                }
+            }
+            panic!("module_init: modules have a cyclic address overlap");
+        }
+    }
+
+    println!(
+        "module_init: relocated {} module(s) ({} copied, {} in place)",
+        count, copied, in_place
+    );
 }

--- a/src/arch/x86_64/cpuid.rs
+++ b/src/arch/x86_64/cpuid.rs
@@ -15,193 +15,103 @@
 //  Solicey <lzoi_lth@163.com>
 
 numeric_enum_macro::numeric_enum! {
-#[repr(u32)]
-#[derive(Debug)]
-pub enum CpuIdEax {
-    VendorInfo = 0x0,
-    FeatureInfo = 0x1,
-    StructuredExtendedFeatureInfo = 0x7,
-    ProcessorFrequencyInfo = 0x16,
-    HypervisorInfo = 0x4000_0000,
-    HypervisorFeatures = 0x4000_0001,
-}
+    #[repr(u32)]
+    #[derive(Debug)]
+    pub enum CpuIdEax {
+        VendorInfo = 0x0,
+        FeatureInfo = 0x1,
+        StructuredExtendedFeatureInfo = 0x7,
+        TimeStampCounterInfo = 0x15,
+        ProcessorFrequencyInfo = 0x16,
+        HypervisorInfo = 0x4000_0000,
+        HypervisorFeatures = 0x4000_0001,
+    }
 }
 
 bitflags::bitflags! {
-    /// Copied from https://docs.rs/raw-cpuid/8.1.2/src/raw_cpuid/lib.rs.html#1290-1294
-    pub struct FeatureInfoFlags: u64 {
+    /// CPUID leaf 7 subleaf 0 ECX feature bits visible to guests.
+    pub struct ExtendedFeaturesEcx: u32 {
+        const SGX_LC = 1_u32 << 30;
+        const RDPID = 1_u32 << 22;
+        const LA57 = 1_u32 << 16;
 
-        // ECX flags
-
-        /// Streaming SIMD Extensions 3 (SSE3). A value of 1 indicates the processor supports this technology.
-        const SSE3 = 1 << 0;
-        /// PCLMULQDQ. A value of 1 indicates the processor supports the PCLMULQDQ instruction
-        const PCLMULQDQ = 1 << 1;
-        /// 64-bit DS Area. A value of 1 indicates the processor supports DS area using 64-bit layout
-        const DTES64 = 1 << 2;
-        /// MONITOR/MWAIT. A value of 1 indicates the processor supports this feature.
-        const MONITOR = 1 << 3;
-        /// CPL Qualified Debug Store. A value of 1 indicates the processor supports the extensions to the  Debug Store feature to allow for branch message storage qualified by CPL.
-        const DSCPL = 1 << 4;
-        /// Virtual Machine Extensions. A value of 1 indicates that the processor supports this technology.
-        const VMX = 1 << 5;
-        /// Safer Mode Extensions. A value of 1 indicates that the processor supports this technology. See Chapter 5, Safer Mode Extensions Reference.
-        const SMX = 1 << 6;
-        /// Enhanced Intel SpeedStep® technology. A value of 1 indicates that the processor supports this technology.
-        const EIST = 1 << 7;
-        /// Thermal Monitor 2. A value of 1 indicates whether the processor supports this technology.
-        const TM2 = 1 << 8;
-        /// A value of 1 indicates the presence of the Supplemental Streaming SIMD Extensions 3 (SSSE3). A value of 0 indicates the instruction extensions are not present in the processor
-        const SSSE3 = 1 << 9;
-        /// L1 Context ID. A value of 1 indicates the L1 data cache mode can be set to either adaptive mode or shared mode. A value of 0 indicates this feature is not supported. See definition of the IA32_MISC_ENABLE MSR Bit 24 (L1 Data Cache Context Mode) for details.
-        const CNXTID = 1 << 10;
-        /// A value of 1 indicates the processor supports FMA extensions using YMM state.
-        const FMA = 1 << 12;
-        /// CMPXCHG16B Available. A value of 1 indicates that the feature is available. See the CMPXCHG8B/CMPXCHG16B Compare and Exchange Bytes section. 14
-        const CMPXCHG16B = 1 << 13;
-        /// Perfmon and Debug Capability: A value of 1 indicates the processor supports the performance   and debug feature indication MSR IA32_PERF_CAPABILITIES.
-        const PDCM = 1 << 15;
-        /// Process-context identifiers. A value of 1 indicates that the processor supports PCIDs and the software may set CR4.PCIDE to 1.
-        const PCID = 1 << 17;
-        /// A value of 1 indicates the processor supports the ability to prefetch data from a memory mapped device.
-        const DCA = 1 << 18;
-        /// A value of 1 indicates that the processor supports SSE4.1.
-        const SSE41 = 1 << 19;
-        /// A value of 1 indicates that the processor supports SSE4.2.
-        const SSE42 = 1 << 20;
-        /// A value of 1 indicates that the processor supports x2APIC feature.
-        const X2APIC = 1 << 21;
-        /// A value of 1 indicates that the processor supports MOVBE instruction.
-        const MOVBE = 1 << 22;
-        /// A value of 1 indicates that the processor supports the POPCNT instruction.
-        const POPCNT = 1 << 23;
-        /// A value of 1 indicates that the processors local APIC timer supports one-shot operation using a TSC deadline value.
-        const TSC_DEADLINE = 1 << 24;
-        /// A value of 1 indicates that the processor supports the AESNI instruction extensions.
-        const AESNI = 1 << 25;
-        /// A value of 1 indicates that the processor supports the XSAVE/XRSTOR processor extended states feature, the XSETBV/XGETBV instructions, and XCR0.
-        const XSAVE = 1 << 26;
-        /// A value of 1 indicates that the OS has enabled XSETBV/XGETBV instructions to access XCR0, and support for processor extended state management using XSAVE/XRSTOR.
-        const OSXSAVE = 1 << 27;
-        /// A value of 1 indicates the processor supports the AVX instruction extensions.
-        const AVX = 1 << 28;
-        /// A value of 1 indicates that processor supports 16-bit floating-point conversion instructions.
-        const F16C = 1 << 29;
-        /// A value of 1 indicates that processor supports RDRAND instruction.
-        const RDRAND = 1 << 30;
-        /// A value of 1 indicates the indicates the presence of a hypervisor.
-        const HYPERVISOR = 1 << 31;
-
-        // EDX flags
-
-        /// Floating Point Unit On-Chip. The processor contains an x87 FPU.
-        const FPU = 1 << (32 + 0);
-        /// Virtual 8086 Mode Enhancements. Virtual 8086 mode enhancements, including CR4.VME for controlling the feature, CR4.PVI for protected mode virtual interrupts, software interrupt indirection, expansion of the TSS with the software indirection bitmap, and EFLAGS.VIF and EFLAGS.VIP flags.
-        const VME = 1 << (32 + 1);
-        /// Debugging Extensions. Support for I/O breakpoints, including CR4.DE for controlling the feature, and optional trapping of accesses to DR4 and DR5.
-        const DE = 1 << (32 + 2);
-        /// Page Size Extension. Large pages of size 4 MByte are supported, including CR4.PSE for controlling the feature, the defined dirty bit in PDE (Page Directory Entries), optional reserved bit trapping in CR3, PDEs, and PTEs.
-        const PSE = 1 << (32 + 3);
-        /// Time Stamp Counter. The RDTSC instruction is supported, including CR4.TSD for controlling privilege.
-        const TSC = 1 << (32 + 4);
-        /// Model Specific Registers RDMSR and WRMSR Instructions. The RDMSR and WRMSR instructions are supported. Some of the MSRs are implementation dependent.
-        const MSR = 1 << (32 + 5);
-        /// Physical Address Extension. Physical addresses greater than 32 bits are supported: extended page table entry formats, an extra level in the page translation tables is defined, 2-MByte pages are supported instead of 4 Mbyte pages if PAE bit is 1.
-        const PAE = 1 << (32 + 6);
-        /// Machine Check Exception. Exception 18 is defined for Machine Checks, including CR4.MCE for controlling the feature. This feature does not define the model-specific implementations of machine-check error logging, reporting, and processor shutdowns. Machine Check exception handlers may have to depend on processor version to do model specific processing of the exception, or test for the presence of the Machine Check feature.
-        const MCE = 1 << (32 + 7);
-        /// CMPXCHG8B Instruction. The compare-and-exchange 8 bytes (64 bits) instruction is supported (implicitly locked and atomic).
-        const CX8 = 1 << (32 + 8);
-        /// APIC On-Chip. The processor contains an Advanced Programmable Interrupt Controller (APIC), responding to memory mapped commands in the physical address range FFFE0000H to FFFE0FFFH (by default - some processors permit the APIC to be relocated).
-        const APIC = 1 << (32 + 9);
-        /// SYSENTER and SYSEXIT Instructions. The SYSENTER and SYSEXIT and associated MSRs are supported.
-        const SEP = 1 << (32 + 11);
-        /// Memory Type Range Registers. MTRRs are supported. The MTRRcap MSR contains feature bits that describe what memory types are supported, how many variable MTRRs are supported, and whether fixed MTRRs are supported.
-        const MTRR = 1 << (32 + 12);
-        /// Page Global Bit. The global bit is supported in paging-structure entries that map a page, indicating TLB entries that are common to different processes and need not be flushed. The CR4.PGE bit controls this feature.
-        const PGE = 1 << (32 + 13);
-        /// Machine Check Architecture. The Machine Check exArchitecture, which provides a compatible mechanism for error reporting in P6 family, Pentium 4, Intel Xeon processors, and future processors, is supported. The MCG_CAP MSR contains feature bits describing how many banks of error reporting MSRs are supported.
-        const MCA = 1 << (32 + 14);
-        /// Conditional Move Instructions. The conditional move instruction CMOV is supported. In addition, if x87 FPU is present as indicated by the CPUID.FPU feature bit, then the FCOMI and FCMOV instructions are supported
-        const CMOV = 1 << (32 + 15);
-        /// Page Attribute Table. Page Attribute Table is supported. This feature augments the Memory Type Range Registers (MTRRs), allowing an operating system to specify attributes of memory accessed through a linear address on a 4KB granularity.
-        const PAT = 1 << (32 + 16);
-        /// 36-Bit Page Size Extension. 4-MByte pages addressing physical memory beyond 4 GBytes are supported with 32-bit paging. This feature indicates that upper bits of the physical address of a 4-MByte page are encoded in bits 20:13 of the page-directory entry. Such physical addresses are limited by MAXPHYADDR and may be up to 40 bits in size.
-        const PSE36 = 1 << (32 + 17);
-        /// Processor Serial Number. The processor supports the 96-bit processor identification number feature and the feature is enabled.
-        const PSN = 1 << (32 + 18);
-        /// CLFLUSH Instruction. CLFLUSH Instruction is supported.
-        const CLFSH = 1 << (32 + 19);
-        /// Debug Store. The processor supports the ability to write debug information into a memory resident buffer. This feature is used by the branch trace store (BTS) and precise event-based sampling (PEBS) facilities (see Chapter 23, Introduction to Virtual-Machine Extensions, in the Intel® 64 and IA-32 Architectures Software Developers Manual, Volume 3C).
-        const DS = 1 << (32 + 21);
-        /// Thermal Monitor and Software Controlled Clock Facilities. The processor implements internal MSRs that allow processor temperature to be monitored and processor performance to be modulated in predefined duty cycles under software control.
-        const ACPI = 1 << (32 + 22);
-        /// Intel MMX Technology. The processor supports the Intel MMX technology.
-        const MMX = 1 << (32 + 23);
-        /// FXSAVE and FXRSTOR Instructions. The FXSAVE and FXRSTOR instructions are supported for fast save and restore of the floating point context. Presence of this bit also indicates that CR4.OSFXSR is available for an operating system to indicate that it supports the FXSAVE and FXRSTOR instructions.
-        const FXSR = 1 << (32 + 24);
-        /// SSE. The processor supports the SSE extensions.
-        const SSE = 1 << (32 + 25);
-        /// SSE2. The processor supports the SSE2 extensions.
-        const SSE2 = 1 << (32 + 26);
-        /// Self Snoop. The processor supports the management of conflicting memory types by performing a snoop of its own cache structure for transactions issued to the bus.
-        const SS = 1 << (32 + 27);
-        /// Max APIC IDs reserved field is Valid. A value of 0 for HTT indicates there is only a single logical processor in the package and software should assume only a single APIC ID is reserved.  A value of 1 for HTT indicates the value in CPUID.1.EBX[23:16] (the Maximum number of addressable IDs for logical processors in this package) is valid for the package.
-        const HTT = 1 << (32 + 28);
-        /// Thermal Monitor. The processor implements the thermal monitor automatic thermal control circuitry (TCC).
-        const TM = 1 << (32 + 29);
-        /// Pending Break Enable. The processor supports the use of the FERR#/PBE# pin when the processor is in the stop-clock state (STPCLK# is asserted) to signal the processor that an interrupt is pending and that the processor should return to normal operation to handle the interrupt. Bit 10 (PBE enable) in the IA32_MISC_ENABLE MSR enables this capability.
-        const PBE = 1 << (32 + 31);
+        const AVX512VPOPCNTDQ = 1_u32 << 14;
+        const TMEEN = 1_u32 << 13;
+        const AVX512BITALG = 1_u32 << 12;
+        const AVX512VNNI = 1_u32 << 11;
+        const VPCLMULQDQ = 1_u32 << 10;
+        const VAES = 1_u32 << 9;
+        const GFNI = 1_u32 << 8;
+        const CETSS = 1_u32 << 7;
+        const AVX512VBMI2 = 1_u32 << 6;
+        const WAITPKG = 1_u32 << 5;
+        const OSPKE = 1_u32 << 4;
+        const PKU = 1_u32 << 3;
+        const UMIP = 1_u32 << 2;
+        const AVX512VBMI = 1_u32 << 1;
+        const PREFETCHWT1 = 1_u32 << 0;
     }
 
-    pub struct ExtendedFeaturesEcx: u32 {
-        /// Bit 0: Prefetch WT1. (Intel® Xeon Phi™ only).
-        const PREFETCHWT1 = 1 << 0;
-        // Bit 01: AVX512_VBMI
-        const AVX512VBMI = 1 << 1;
-        /// Bit 02: UMIP. Supports user-mode instruction prevention if 1.
-        const UMIP = 1 << 2;
-        /// Bit 03: PKU. Supports protection keys for user-mode pages if 1.
-        const PKU = 1 << 3;
-        /// Bit 04: OSPKE. If 1, OS has set CR4.PKE to enable protection keys (and the RDPKRU/WRPKRU instruc-tions).
-        const OSPKE = 1 << 4;
-        /// Bit 5: WAITPKG
-        const WAITPKG = 1 << 5;
-        /// Bit 6: AV512_VBMI2
-        const AVX512VBMI2 = 1 << 6;
-        /// Bit 7: CET_SS. Supports CET shadow stack features if 1. Processors that set this bit define bits 0..2 of the
-        /// IA32_U_CET and IA32_S_CET MSRs. Enumerates support for the following MSRs:
-        /// IA32_INTERRUPT_SPP_TABLE_ADDR, IA32_PL3_SSP, IA32_PL2_SSP, IA32_PL1_SSP, and IA32_PL0_SSP.
-        const CETSS = 1 << 7;
-        /// Bit 8: GFNI
-        const GFNI = 1 << 8;
-        /// Bit 9: VAES
-        const VAES = 1 << 9;
-        /// Bit 10: VPCLMULQDQ
-        const VPCLMULQDQ = 1 << 10;
-        /// Bit 11: AVX512_VNNI
-        const AVX512VNNI = 1 << 11;
-        /// Bit 12: AVX512_BITALG
-        const AVX512BITALG = 1 << 12;
-        /// Bit 13: TME_EN. If 1, the following MSRs are supported: IA32_TME_CAPABILITY, IA32_TME_ACTIVATE,
-        /// IA32_TME_EXCLUDE_MASK, and IA32_TME_EXCLUDE_BASE.
-        const TMEEN = 1 << 13;
-        /// Bit 14: AVX512_VPOPCNTDQ
-        const AVX512VPOPCNTDQ = 1 << 14;
+    /// CPUID leaf 1 feature mask: ECX occupies low bits, EDX high bits.
+    pub struct FeatureInfoFlags: u64 {
+        const PBE = 1_u64 << (32 + 31);
+        const TM = 1_u64 << (32 + 29);
+        const HTT = 1_u64 << (32 + 28);
+        const SS = 1_u64 << (32 + 27);
+        const SSE2 = 1_u64 << (32 + 26);
+        const SSE = 1_u64 << (32 + 25);
+        const FXSR = 1_u64 << (32 + 24);
+        const MMX = 1_u64 << (32 + 23);
+        const ACPI = 1_u64 << (32 + 22);
+        const DS = 1_u64 << (32 + 21);
+        const CLFSH = 1_u64 << (32 + 19);
+        const PSN = 1_u64 << (32 + 18);
+        const PSE36 = 1_u64 << (32 + 17);
+        const PAT = 1_u64 << (32 + 16);
+        const CMOV = 1_u64 << (32 + 15);
+        const MCA = 1_u64 << (32 + 14);
+        const PGE = 1_u64 << (32 + 13);
+        const MTRR = 1_u64 << (32 + 12);
+        const SEP = 1_u64 << (32 + 11);
+        const APIC = 1_u64 << (32 + 9);
+        const CX8 = 1_u64 << (32 + 8);
+        const MCE = 1_u64 << (32 + 7);
+        const PAE = 1_u64 << (32 + 6);
+        const MSR = 1_u64 << (32 + 5);
+        const TSC = 1_u64 << (32 + 4);
+        const PSE = 1_u64 << (32 + 3);
+        const DE = 1_u64 << (32 + 2);
+        const VME = 1_u64 << (32 + 1);
+        const FPU = 1_u64 << (32 + 0);
 
-        // Bit 15: Reserved.
-
-        /// Bit 16: Supports 57-bit linear addresses and five-level paging if 1.
-        const LA57 = 1 << 16;
-
-        // Bits 21 - 17: The value of MAWAU used by the BNDLDX and BNDSTX instructions in 64-bit mode
-
-        /// Bit 22: RDPID. RDPID and IA32_TSC_AUX are available if 1.
-        const RDPID = 1 << 22;
-
-        // Bits 29 - 23: Reserved.
-
-        /// Bit 30: SGX_LC. Supports SGX Launch Configuration if 1.
-        const SGX_LC = 1 << 30;
+        const HYPERVISOR = 1_u64 << 31;
+        const RDRAND = 1_u64 << 30;
+        const F16C = 1_u64 << 29;
+        const AVX = 1_u64 << 28;
+        const OSXSAVE = 1_u64 << 27;
+        const XSAVE = 1_u64 << 26;
+        const AESNI = 1_u64 << 25;
+        const TSC_DEADLINE = 1_u64 << 24;
+        const POPCNT = 1_u64 << 23;
+        const MOVBE = 1_u64 << 22;
+        const X2APIC = 1_u64 << 21;
+        const SSE42 = 1_u64 << 20;
+        const SSE41 = 1_u64 << 19;
+        const DCA = 1_u64 << 18;
+        const PCID = 1_u64 << 17;
+        const PDCM = 1_u64 << 15;
+        const CMPXCHG16B = 1_u64 << 13;
+        const FMA = 1_u64 << 12;
+        const CNXTID = 1_u64 << 10;
+        const SSSE3 = 1_u64 << 9;
+        const TM2 = 1_u64 << 8;
+        const EIST = 1_u64 << 7;
+        const SMX = 1_u64 << 6;
+        const VMX = 1_u64 << 5;
+        const DSCPL = 1_u64 << 4;
+        const MONITOR = 1_u64 << 3;
+        const DTES64 = 1_u64 << 2;
+        const PCLMULQDQ = 1_u64 << 1;
+        const SSE3 = 1_u64 << 0;
     }
 }

--- a/src/arch/x86_64/hpet.rs
+++ b/src/arch/x86_64/hpet.rs
@@ -17,7 +17,7 @@
 use crate::memory::VirtAddr;
 use bit_field::BitField;
 use core::{arch::x86_64::_rdtsc, time::Duration, u32};
-use spin::Mutex;
+use spin::{Mutex, Once};
 use tock_registers::{
     interfaces::{Readable, Writeable},
     register_structs,
@@ -203,7 +203,19 @@ pub fn wait_millis(millis: u64) {
     HPET.wait_millis(millis);
 }
 
+/// Cached result of the one-time TSC-frequency calibration.
+///
+/// Calibration busy-waits on the HPET for tens of milliseconds, so it must run
+/// at most once: a guest can execute CPUID leaf 0x15/0x16 in a tight loop, and
+/// re-calibrating on every exit would let it stall the physical CPU at will.
+static TSC_FREQ_MHZ: Once<Option<u32>> = Once::new();
+
+/// TSC frequency in MHz, calibrated against the HPET on first use and cached.
 pub fn get_tsc_freq_mhz() -> Option<u32> {
+    *TSC_FREQ_MHZ.call_once(calibrate_tsc_freq_mhz)
+}
+
+fn calibrate_tsc_freq_mhz() -> Option<u32> {
     let mut best_freq_mhz = u32::MAX;
     for _ in 0..5 {
         let tsc_start = unsafe { _rdtsc() };
@@ -213,7 +225,10 @@ pub fn get_tsc_freq_mhz() -> Option<u32> {
         let hpet_end = current_ticks();
 
         let nanos = ticks_to_nanos(hpet_end.wrapping_sub(hpet_start));
-        let freq_mhz = ((tsc_end - tsc_start) * 1_000 / nanos) as u32;
+        if nanos == 0 {
+            continue;
+        }
+        let freq_mhz = (tsc_end.wrapping_sub(tsc_start) * 1_000 / nanos) as u32;
 
         if freq_mhz < best_freq_mhz {
             best_freq_mhz = freq_mhz;

--- a/src/arch/x86_64/trap.rs
+++ b/src/arch/x86_64/trap.rs
@@ -127,6 +127,22 @@ fn handle_cpuid(arch_cpu: &mut ArchCpu) -> HvResult {
 
     if let Ok(function) = rax {
         res = match function {
+            CpuIdEax::VendorInfo => {
+                // EAX of leaf 0 is the highest basic leaf the CPU advertises
+                // (Intel SDM Vol.2A). We synthesize leaf 0x15 (TSC/crystal) and
+                // a guest derives its TSC frequency from it, so when calibration
+                // succeeded ensure the maximum advertised leaf is at least 0x15.
+                // We deliberately do NOT raise it to 0x16: leaf 0x16 (processor
+                // frequency) has bus/reference-clock semantics in ECX that we
+                // cannot synthesize faithfully, so we never *newly* advertise it.
+                // On a host whose maximum is already >= 0x15 (any modern CPU)
+                // this is a no-op; it only matters on a host that hides 0x15.
+                let mut res = cpuid!(regs.rax, regs.rcx);
+                if hpet::get_tsc_freq_mhz().is_some() && res.eax < 0x15 {
+                    res.eax = 0x15;
+                }
+                res
+            }
             CpuIdEax::FeatureInfo => {
                 let mut res = cpuid!(regs.rax, regs.rcx);
                 let mut ecx = FeatureInfoFlags::from_bits_truncate(res.ecx as _);
@@ -153,12 +169,41 @@ fn handle_cpuid(arch_cpu: &mut ArchCpu) -> HvResult {
 
                 res
             }
+            CpuIdEax::TimeStampCounterInfo => {
+                // Leaf 0x15 reports the TSC / core-crystal-clock relation
+                // (Intel SDM Vol.2A, CPUID): EAX = ratio denominator, EBX =
+                // ratio numerator, ECX = core-crystal-clock frequency in Hz, and
+                // the effective TSC frequency is `ECX * EBX / EAX`. The hardware
+                // leaf is frequently zeroed under virtualization, so synthesize
+                // the relation from the TSC frequency the hypervisor calibrated
+                // via the HPET. Expose it as a 1 MHz crystal (ECX) scaled by
+                // `freq_mhz` (EBX) over 1 (EAX); this reproduces the calibrated
+                // TSC frequency exactly (`1_000_000 * freq_mhz`) while keeping
+                // every field within u32, whereas the naive `freq_mhz *
+                // 1_000_000` in ECX overflows for nominal TSCs above ~4.29 GHz.
+                if let Some(freq_mhz) = hpet::get_tsc_freq_mhz() {
+                    CpuIdResult {
+                        eax: 1,
+                        ebx: freq_mhz,
+                        ecx: 1_000_000,
+                        edx: 0,
+                    }
+                } else {
+                    cpuid!(regs.rax, regs.rcx)
+                }
+            }
             CpuIdEax::ProcessorFrequencyInfo => {
                 if let Some(freq_mhz) = hpet::get_tsc_freq_mhz() {
+                    // Intel SDM Vol.2A CPUID.16H: EAX = processor base frequency
+                    // (MHz), EBX = maximum frequency (MHz), ECX = bus/reference
+                    // frequency (MHz). We approximate base/max with the
+                    // calibrated TSC frequency, but the bus/reference clock is
+                    // unknown under virtualization, so ECX is reported as 0
+                    // ("not enumerated") rather than mis-stating it as the TSC.
                     CpuIdResult {
                         eax: freq_mhz,
                         ebx: freq_mhz,
-                        ecx: freq_mhz,
+                        ecx: 0,
                         edx: 0,
                     }
                 } else {
@@ -275,7 +320,12 @@ fn handle_io_instruction(arch_cpu: &mut ArchCpu, exit_info: &VmxExitInfo) -> HvR
         {
             handle_pci_config_port_write(&io_info, value);
         } else if UART_COM1_PORT.contains(&io_info.port) {
-            virt_console_io_write(io_info.port, value);
+            // The legacy COM1 serial port is owned by the root zone. Drop a
+            // non-root zone's writes so it cannot drive or interleave the
+            // physical/root console (a non-root guest uses virtio-console).
+            if this_zone_id() == 0 {
+                virt_console_io_write(io_info.port, value);
+            }
         } else {
             /* info!(
                 "unhandled port io write {:x} value: {:x}",
@@ -288,7 +338,19 @@ fn handle_io_instruction(arch_cpu: &mut ArchCpu, exit_info: &VmxExitInfo) -> HvR
         {
             value = handle_pci_config_port_read(&io_info);
         } else if UART_COM1_PORT.contains(&io_info.port) {
-            value = virt_console_io_read(io_info.port);
+            value = if this_zone_id() == 0 {
+                virt_console_io_read(io_info.port)
+            } else {
+                // Inert COM1 for a non-root zone: report the transmitter as
+                // always ready (LSR THRE|TEMT) and no received data, so the
+                // guest's 16550 driver neither blocks nor observes root console
+                // state. LSR is at COM1 base + 5.
+                if io_info.port == UART_COM1_PORT.start + 5 {
+                    0x60
+                } else {
+                    0
+                }
+            };
         } else {
             // info!("unhandled port io read {:x}", io_info.port);
             value = 0x0;

--- a/src/device/irqchip/pic/ioapic.rs
+++ b/src/device/irqchip/pic/ioapic.rs
@@ -16,17 +16,18 @@
 
 use crate::{
     arch::{
-        acpi::{get_apic_id, get_cpu_id},
+        acpi::{get_apic_id, try_get_cpu_id},
         cpu::this_cpu_id,
         idt, ipi,
         mmio::MMIoDevice,
         zone::HvArchZoneConfig,
     },
+    cpu_data::{this_zone, CpuSet},
     device::irqchip::pic::inject_vector,
     error::HvResult,
     memory::{GuestPhysAddr, MMIOAccess},
     platform::ROOT_ZONE_IOAPIC_BASE,
-    zone::{this_zone_id, Zone},
+    zone::{find_zone, this_zone_id, Zone},
 };
 use alloc::{sync::Arc, vec::Vec};
 use bit_field::BitField;
@@ -85,16 +86,29 @@ impl VirtIoApic {
         if gpa == 0 {
             return Ok(ioapic.lock().cur_reg as _);
         }
-        assert!(gpa == 0x10);
+        // Only IOREGSEL (offset 0) and IOWIN (offset 0x10) exist; any other
+        // window offset a guest pokes reads back as zero rather than panicking.
+        if gpa != 0x10 {
+            return Ok(0);
+        }
 
         let inner = ioapic.lock();
         match inner.cur_reg {
             IoApicReg::ID => Ok(0),
             IoApicReg::VERSION => Ok(IOAPIC_MAX_REDIRECT_ENTRIES << 16 | 0x11), // max redirect entries: 0x17, version: 0x11
             IoApicReg::ARBITRATION => Ok(0),
+            reg if reg < IoApicReg::TABLE_BASE => Ok(0), // reserved register window
             mut reg => {
                 reg -= IoApicReg::TABLE_BASE;
                 let index = (reg >> 1) as usize;
+                if zone_id != 0 && index == irqs::UART_COM1_IRQ as usize {
+                    // The legacy COM1 UART is owned by the root zone. Present a
+                    // well-formed *masked* redirection entry to other zones (mask
+                    // bit 16 set, vector/destination zero) rather than an
+                    // all-ones value, which would otherwise read back as an
+                    // entry with a bogus vector 0xff and delivery mode 7.
+                    return Ok(if reg % 2 == 0 { 1u64 << 16 } else { 0 });
+                }
                 if let Some(entry) = inner.rte.get(index) {
                     if reg % 2 == 0 {
                         Ok((*entry).get_bits(0..=31))
@@ -117,28 +131,43 @@ impl VirtIoApic {
         let zone_id = this_zone_id();
         let ioapic = self.inner.get(zone_id).unwrap();
         if gpa == 0 {
-            ioapic.lock().cur_reg = value as _;
+            // IOREGSEL is an 8-bit register; keep only the low byte so a read
+            // returns the architectural value.
+            ioapic.lock().cur_reg = (value as u32) & 0xff;
             return Ok(());
         }
-        assert!(gpa == 0x10);
+        // Only IOWIN (offset 0x10) is writable here; ignore stray window offsets
+        // instead of panicking on guest-controlled MMIO.
+        if gpa != 0x10 {
+            return Ok(());
+        }
 
         let mut inner = ioapic.lock();
         match inner.cur_reg {
             IoApicReg::ID | IoApicReg::VERSION | IoApicReg::ARBITRATION => {}
+            reg if reg < IoApicReg::TABLE_BASE => {} // reserved register window
             mut reg => {
                 reg -= IoApicReg::TABLE_BASE;
                 let index = (reg >> 1) as usize;
+                // The legacy COM1 UART redirection entry is owned by the root
+                // zone. Drop a non-root zone's writes to it so it cannot reclaim
+                // or reprogram COM1 delivery (reads already return a masked
+                // entry for this index).
+                if zone_id != 0 && index == irqs::UART_COM1_IRQ as usize {
+                    return Ok(());
+                }
                 if let Some(entry) = inner.rte.get_mut(index) {
+                    // Store the guest's write verbatim so it reads back what it
+                    // wrote. Destination containment is enforced at injection
+                    // time (see `contain_dest_cpu`), which is the single choke
+                    // point for *every* RTE shape — including a guest that writes
+                    // only the low dword to unmask a vector while leaving a
+                    // default/out-of-zone destination, or that toggles logical
+                    // destination mode after a high-dword write.
                     if reg % 2 == 0 {
                         entry.set_bits(0..=31, value.get_bits(0..=31));
                     } else {
                         entry.set_bits(32..=63, value.get_bits(0..=31));
-
-                        /*if zone_id == 0 {
-                            // info!("1 write {:x} entry: {:x?}", index, *entry);
-                            // only root zone modify the real I/O APIC
-                            // unsafe { configure_gsi_from_raw(index as _, *entry) };
-                        }*/
                     }
                     if zone_id == 0 {
                         // only root zone modify the real I/O APIC
@@ -151,29 +180,76 @@ impl VirtIoApic {
     }
 
     fn get_irq_cpu(&self, irq: usize, zone_id: usize) -> Option<usize> {
-        let ioapic = self.inner.get(zone_id).unwrap();
-        if let Some(entry) = ioapic.lock().rte.get(irq) {
-            let dest = get_cpu_id(entry.get_bits(56..=63) as usize);
-            return Some(dest);
+        // The legacy COM1 UART is root-owned (its non-root RTE always reads back
+        // masked); a non-root zone has no target for it, so report no CPU rather
+        // than handing back the zone's first CPU.
+        if zone_id != 0 && irq == irqs::UART_COM1_IRQ as usize {
+            return None;
         }
-        None
+        let cpu_set = find_zone(zone_id)?.cpu_set();
+        let ioapic = self.inner.get(zone_id)?;
+        let entry = *ioapic.lock().rte.get(irq)?;
+        // Mirror `trigger`'s injection gate: a masked entry (mask bit 16) or one
+        // whose vector (bits 0..=7) is below 0x20 never injects, so it has no
+        // destination CPU. This keeps an all-zero or masked RTE from resolving to
+        // the zone's first CPU, which would be inconsistent with delivery.
+        if entry.get_bit(16) || (entry.get_bits(0..=7) as u8) < 0x20 {
+            return None;
+        }
+        contain_dest_cpu(zone_id, &cpu_set, entry)
     }
 
     fn trigger(&self, irq: usize, allow_repeat: bool) -> HvResult {
         let zone_id = this_zone_id();
+        let cpu_set = this_zone().cpu_set();
         let ioapic = self.inner.get(zone_id).unwrap();
-        if let Some(entry) = ioapic.lock().rte.get(irq) {
-            // TODO: physical & logical mode
-            let dest = get_cpu_id(entry.get_bits(56..=63) as usize);
+        let entry = ioapic.lock().rte.get(irq).copied();
+        if let Some(entry) = entry {
             let masked = entry.get_bit(16);
             let vector = entry.get_bits(0..=7) as u8;
-            // info!("trigger hv: {:x} zone: {:x}", vector, zone_id);
             if !masked && vector >= 0x20 {
-                inject_vector(dest, vector, None, allow_repeat);
+                // Containment choke point: resolve the destination to an in-zone
+                // CPU with a fallible lookup, never trusting the guest-written
+                // destination byte/mode, so a non-root zone cannot deliver an
+                // interrupt to a CPU outside itself and a bogus APIC id cannot
+                // panic the hypervisor.
+                if let Some(dest) = contain_dest_cpu(zone_id, &cpu_set, entry) {
+                    inject_vector(dest, vector, None, allow_repeat);
+                }
             }
         }
         Ok(())
     }
+}
+
+/// Resolve the CPU an IOAPIC redirection entry should deliver to, keeping a
+/// non-root zone's interrupts contained.
+///
+/// The root zone (`zone_id == 0`) programs real hardware APIC ids and is
+/// trusted. For a non-root zone only a *physical-mode* entry whose destination
+/// APIC id resolves to one of the zone's own CPUs is honored; a logical-mode
+/// entry (RTE bit 11), an unknown APIC id, or an out-of-zone CPU is redirected
+/// to one of the zone's CPUs. The APIC-id lookup is fallible, so a garbage
+/// guest destination can never panic the hypervisor. Returns `None` only for a
+/// zone with no usable CPU.
+fn contain_dest_cpu(zone_id: usize, cpu_set: &CpuSet, entry: u64) -> Option<usize> {
+    if zone_id == 0 {
+        return try_get_cpu_id(entry.get_bits(56..=63) as usize);
+    }
+    if !entry.get_bit(11) {
+        // The destination byte (RTE bits 56..=63) is read as the full 8-bit
+        // field. In legacy xAPIC physical mode only bits 56..=59 are the APIC id
+        // and bits 60..=63 are reserved, while logical mode uses the full byte;
+        // reading the full byte is containment-safe here because an out-of-zone
+        // or unknown id is clamped to an in-zone CPU below, and it matches the
+        // small x2APIC ids this platform actually uses.
+        if let Some(cpu) = try_get_cpu_id(entry.get_bits(56..=63) as usize) {
+            if cpu_set.contains_cpu(cpu) {
+                return Some(cpu);
+            }
+        }
+    }
+    cpu_set.first_cpu()
 }
 
 impl Zone {
@@ -229,5 +305,6 @@ pub fn get_irq_cpu(irq: usize, zone_id: usize) -> usize {
         .get()
         .unwrap()
         .get_irq_cpu(irq, zone_id)
-        .unwrap()
+        .or_else(|| find_zone(zone_id).and_then(|z| z.cpu_set().first_cpu()))
+        .unwrap_or(0)
 }


### PR DESCRIPTION
Grab bag of x86_64 hardening, all generic, none of it Asterinas-specific:

1. `acpi.rs`: `get_cpu_id()` panics on an unrecognized APIC id. Added
   `try_get_cpu_id()` — same lookup, returns `None` instead.
2. `boot.rs`: `module_init()` had no bounds checks on the multiboot2 tag
   walk (untrusted GRUB data), a hardcoded assumption of exactly one
   module, and read module data with an unbounded `CStr::from_ptr`.
   Rewrote to: bound every read against the declared info-buffer size,
   support up to `MAX_BOOT_MODULES = 16`, and schedule relocations
   topologically so a module's destination never overwrites another
   module's not-yet-copied source (was a straight ordered copy before — a
   bad layout corrupts data silently).
3. `cpuid.rs`: added `CpuIdEax::TimeStampCounterInfo` (leaf 0x15). No
   behavior yet — wired up in trap.rs below.
4. `hpet.rs`: `calibrate_tsc_freq_mhz()` was called fresh on every CPUID
   exit. Tens of ms of HPET busy-wait each time — a guest looping on CPUID
   can stall the physical CPU. Cached behind `spin::Once`. Also fixed a
   zero-`nanos` denominator and an overflow in the calc (`wrapping_sub`).
5. `trap.rs`: `handle_cpuid` now answers leaf 0x15 (TSC/crystal ratio) and
   stops misreporting leaf 0x16 ECX (bus/reference clock — can't be
   synthesized honestly, now reports 0 instead of the TSC frequency it was
   wrongly putting there before). `handle_io_instruction`: legacy COM1
   (`UART_COM1_PORT`) now gated to zone 0 only — non-root zones get a
   synthetic always-ready LSR readback instead of touching the real port.
6. `ioapic.rs`: reserved-register accesses were `assert!`-guarded (panic on
   out-of-range guest access). Changed to no-op reads/writes. `IOREGSEL`
   now masked to its real 8-bit width. New `contain_dest_cpu()` replaces
   `get_cpu_id(...).unwrap()` in `get_irq_cpu`/`trigger` — for non-root
   zones, only honors a destination CPU that's actually inside that zone's
   own `CpuSet`; falls back to the zone's first CPU otherwise instead of
   panicking. COM1's IRQ masked from non-root reads too.

All of this already exists on `dev` unmodified — verified none of these
symbols/behaviors have any forward dependency on later work.