### PR TITLE
fix: small VT-d, VirtIO, and mapper correctness issues

### DIFF
--- a/src/device/iommu/intel_vtd/vtd_hw.rs
+++ b/src/device/iommu/intel_vtd/vtd_hw.rs
@@ -362,12 +362,14 @@ impl Vtd {
         }
         self.qi_tail = (self.qi_tail + QI_INV_ENTRY_SIZE) % INVALIDATION_QUEUE_SIZE;
 
-        qi_status = INV_STATUS_INCOMPLETED as u32;
+        unsafe {
+            core::ptr::write_volatile(&mut qi_status, INV_STATUS_INCOMPLETED as u32);
+        }
         self.mmio_write_u32(DMAR_IQT_REG, self.qi_tail as _);
 
         let start_tick = current_time_nanos();
-        while (qi_status != INV_STATUS_COMPLETED as _) {
-            if (current_time_nanos() - start_tick > 1000000) {
+        while unsafe { core::ptr::read_volatile(qi_status_ptr) } != INV_STATUS_COMPLETED as u32 {
+            if current_time_nanos() - start_tick > 1000000 {
                 error!("issue qi request failed!");
                 break;
             }

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -255,7 +255,7 @@ struct ReqAgent<'a> {
 }
 
 impl<'a> ReqAgent<'a> {
-    fn region(&self) -> &mut VirtioBridge {
+    fn region(&mut self) -> &mut VirtioBridge {
         unsafe { &mut *(self.base as *mut VirtioBridge) }
     }
 
@@ -294,7 +294,7 @@ pub struct ResAgent<'a> {
 }
 
 impl<'a> ResAgent<'a> {
-    fn region(&self) -> &mut VirtioBridge {
+    fn region(&mut self) -> &mut VirtioBridge {
         unsafe { &mut *(self.base as *mut VirtioBridge) }
     }
 

--- a/src/memory/mapper.rs
+++ b/src/memory/mapper.rs
@@ -54,7 +54,6 @@ impl<VA: From<usize> + Into<usize> + Copy> MemoryRegion<VA> {
         flags: MemFlags,
     ) -> Self {
         let start_vaddr = start_vaddr.into();
-        let start_paddr = start_paddr;
         // bug: vaddr > paddr?
         let phys_virt_offset = start_vaddr.wrapping_sub(start_paddr);
         Self::new(


### PR DESCRIPTION
Three unrelated one-file fixes, bundled because they're all tiny and none
of them touch anything else in this queue:

1. `vtd_hw.rs`: `issue_qi_request()` polls `qi_status: u32` in a plain
   loop. The IOMMU writes that memory via DMA — the compiler has no idea,
   so it's free to treat the loop condition as invariant and hang or
   optimize the wait away entirely. Switched to `write_volatile` (initial
   state) / `read_volatile` (poll).
2. `virtio_trampoline.rs`: `ReqAgent::region()` / `ResAgent::region()` took
   `&self`, returned `&mut VirtioBridge` via an unsafe cast. Unsound
   pattern even though current callers happen to already hold `&mut self`.
   Changed both to take `&mut self`.
3. `mapper.rs`: `let start_paddr = start_paddr;` — dead self-assignment,
   deleted.