### PR TITLE
config: complete PCI fields in zone examples

### DIFF
--- a/platform/aarch64/ok6254-c/configs/zone1-linux.json
+++ b/platform/aarch64/ok6254-c/configs/zone1-linux.json
@@ -82,5 +82,6 @@
         "gicr_size": "0xc0000",
         "gits_base": "0x1820000",
         "gits_size": "0x10000"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/aarch64/phytium-pi/configs/zone1-linux.json
+++ b/platform/aarch64/phytium-pi/configs/zone1-linux.json
@@ -50,5 +50,6 @@
             "gicr_size": "0x80000",
             "gits_base": "0x0",
             "gits_size": "0x0"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/aarch64/qemu-gicv2/configs/zone1-linux.json
+++ b/platform/aarch64/qemu-gicv2/configs/zone1-linux.json
@@ -48,5 +48,6 @@
     "gich_size": "0x10000",
     "gicv_base": "0x8040000",
     "gicv_size": "0x10000"
-  }
+  },
+  "pci_config": []
 }

--- a/platform/aarch64/qemu-gicv3/configs/zone1-ruxos.json
+++ b/platform/aarch64/qemu-gicv3/configs/zone1-ruxos.json
@@ -39,5 +39,6 @@
         "gicr_size": "0xf60000",
         "gits_base": "0x8080000",
         "gits_size": "0x20000"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/aarch64/rk3568/configs/linux2.json
+++ b/platform/aarch64/rk3568/configs/linux2.json
@@ -44,5 +44,6 @@
         "gicr_size": "0xc0000",
         "gits_base": "0x0",
         "gits_size": "0x0"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/aarch64/rk3588/configs/zone1-linux.json
+++ b/platform/aarch64/rk3588/configs/zone1-linux.json
@@ -45,6 +45,6 @@
         "gicr_size": "0x100000",
 	    "gits_base": "0x0",
         "gits_size": "0x0"
-    }
+    },
+    "pci_config": []
 }
-

--- a/platform/aarch64/sysoul_x3300/configs/zone1-android.json
+++ b/platform/aarch64/sysoul_x3300/configs/zone1-android.json
@@ -314,5 +314,6 @@
     "gicr_size": "0x100000",
     "gits_base": "0x0",
     "gits_size": "0x0"
-  }
+  },
+  "pci_config": []
 }

--- a/platform/loongarch64/ls3a6000/configs/zone1-linux.json
+++ b/platform/loongarch64/ls3a6000/configs/zone1-linux.json
@@ -133,6 +133,9 @@
         "bus": "0x6",
         "device": "0x1",
         "function": "0x0",
+        "v_bus": "0x6",
+        "v_device": "0x1",
+        "v_function": "0x0",
         "dev_type": "0"
     }]
 }

--- a/platform/loongarch64/ls3a6000/configs/zone2-linux.json
+++ b/platform/loongarch64/ls3a6000/configs/zone2-linux.json
@@ -121,6 +121,9 @@
         "bus": "0x6",
         "device": "0x2",
         "function": "0x0",
+        "v_bus": "0x6",
+        "v_device": "0x2",
+        "v_function": "0x0",
         "dev_type": "0"
     }]
 }

--- a/platform/loongarch64/ls3a6000/configs/zone3-linux.json
+++ b/platform/loongarch64/ls3a6000/configs/zone3-linux.json
@@ -121,6 +121,9 @@
         "bus": "0x6",
         "device": "0x3",
         "function": "0x0",
+        "v_bus": "0x6",
+        "v_device": "0x3",
+        "v_function": "0x0",
         "dev_type": "0"
     }]
 }

--- a/platform/riscv64/hifive-premier-p550/configs/zone1-linux.json
+++ b/platform/riscv64/hifive-premier-p550/configs/zone1-linux.json
@@ -59,5 +59,6 @@
         "plic_size": "0x4000000",
         "aplic_base": "0xd000000",
         "aplic_size": "0x8000"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/riscv64/megrez/configs/zone1-linux.json
+++ b/platform/riscv64/megrez/configs/zone1-linux.json
@@ -71,5 +71,6 @@
         "plic_size": "0x4000000",
         "aplic_base": "0xd000000",
         "aplic_size": "0x8000"
-    }
+    },
+    "pci_config": []
 }

--- a/platform/riscv64/qemu-aia/configs/zone1-linux-passthrough.json
+++ b/platform/riscv64/qemu-aia/configs/zone1-linux-passthrough.json
@@ -60,6 +60,9 @@
             "bus": "0x0",
             "device": "0x0",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x0",
+            "v_function": "0x0",
             "dev_type": "0"
         },
         {
@@ -67,6 +70,9 @@
             "bus": "0x0",
             "device": "0x2",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x2",
+            "v_function": "0x0",
             "dev_type": "0"
         }
     ]

--- a/platform/riscv64/qemu-aia/configs/zone1-linux-virtio.json
+++ b/platform/riscv64/qemu-aia/configs/zone1-linux-virtio.json
@@ -59,6 +59,9 @@
             "bus": "0x0",
             "device": "0x0",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x0",
+            "v_function": "0x0",
             "dev_type": "0"
         },
         {
@@ -66,6 +69,9 @@
             "bus": "0x0",
             "device": "0x2",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x2",
+            "v_function": "0x0",
             "dev_type": "0"
         }
     ]

--- a/platform/riscv64/qemu-plic/configs/zone1-linux-passthrough.json
+++ b/platform/riscv64/qemu-plic/configs/zone1-linux-passthrough.json
@@ -59,6 +59,9 @@
             "bus": "0x0",
             "device": "0x0",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x0",
+            "v_function": "0x0",
             "dev_type": "0"
         },
         {
@@ -66,6 +69,9 @@
             "bus": "0x0",
             "device": "0x2",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x2",
+            "v_function": "0x0",
             "dev_type": "0"
         }
     ]

--- a/platform/riscv64/qemu-plic/configs/zone1-linux-virtio.json
+++ b/platform/riscv64/qemu-plic/configs/zone1-linux-virtio.json
@@ -53,6 +53,9 @@
             "bus": "0x0",
             "device": "0x0",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x0",
+            "v_function": "0x0",
             "dev_type": "0"
         },
         {
@@ -60,6 +63,9 @@
             "bus": "0x0",
             "device": "0x2",
             "function": "0x0",
+            "v_bus": "0x0",
+            "v_device": "0x2",
+            "v_function": "0x0",
             "dev_type": "0"
         }
     ]


### PR DESCRIPTION
## Summary

- add empty `pci_config` arrays to zone examples without PCI buses
- add missing virtual BDF fields to LoongArch and RISC-V PCI device assignments
- use identity mappings where the virtual BDF matches the physical BDF
- align zone examples with the current hvisor-tool parser requirements

## Validation

- parsed all JSON files under `hvisor/platform`
- confirmed no missing PCI configuration fields remain