### PR TITLE
build(kconfig): support older Python environments

### DIFF
--- a/tools/kconfig/bootstrap_venv.sh
+++ b/tools/kconfig/bootstrap_venv.sh
@@ -11,9 +11,11 @@ if [[ ! -f "${REQ}" ]]; then
 	exit 1
 fi
 
-if [[ -x "${VENV}/bin/python" ]] && "${VENV}/bin/python" -c "import kconfiglib" 2>/dev/null; then
+if [[ -x "${VENV}/bin/python" ]] && "${VENV}/bin/python" -c 'import kconfiglib, sys; __import__("tomllib" if sys.version_info >= (3, 11) else "tomli")' 2>/dev/null; then
 	exit 0
 fi
 
-python3 -m venv "${VENV}"
+if [[ ! -x "${VENV}/bin/pip" ]]; then
+	python3 -m venv "${VENV}"
+fi
 "${VENV}/bin/pip" install -q -r "${REQ}"


### PR DESCRIPTION
## Summary

Improve Kconfig virtual environment reuse and dependency recovery.

##  Changes

  - Validate both `kconfiglib` and the Python-version-appropriate TOML parser before reusing an existing virtual environment.
  - Use `tomllib` on Python 3.11 and newer, and `tomli` on older Python versions when validating the environment.
  - Install missing dependencies into an existing virtual environment when `pip` is available.
  - Create the virtual environment only when it does not already provide `pip`.