### PR TITLE
loongarch64: update Loongson platform layouts for SMP zones

### DIFF
--- a/platform/loongarch64/ls3a5000/board.rs
+++ b/platform/loongarch64/ls3a5000/board.rs
@@ -77,8 +77,11 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
         mem_type: MEM_TYPE_IO,
         physical_start: 0x1fe00000,
         virtual_start: 0x1fe00000,
-        size: 0x1000,
-    }, // uart0
+        size: 0x3000,
+    }, // IOCSR MMIO: uart0, IPI, EXTIOI.
+    // Reference:
+    //  IPI: <https://loongson.github.io/LoongArch-Documentation/Loongson-3A5000-usermanual-EN.html#accessing-by-address-3>
+    //  EXTIOI: <https://loongson.github.io/LoongArch-Documentation/Loongson-3A5000-usermanual-EN.html#accessing-by-address-5>
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_IO,
         physical_start: 0x10080000,

--- a/platform/loongarch64/ls3a6000/board.rs
+++ b/platform/loongarch64/ls3a6000/board.rs
@@ -17,68 +17,127 @@
 use crate::pci_dev;
 use crate::{arch::zone::HvArchZoneConfig, config::*, pci::vpci_dev::VpciDevType};
 
-pub const BOARD_NAME: &str = "ls3a5000";
+pub const BOARD_NAME: &str = "ls3a6000";
 
 pub const BOARD_NCPUS: usize = 4;
 
 pub const ROOT_ZONE_DTB_ADDR: u64 = 0x10000f000;
 pub const ROOT_ZONE_KERNEL_ADDR: u64 = 0x200000;
-pub const ROOT_ZONE_ENTRY: u64 = 0x9000000000d8c000;
-pub const ROOT_ZONE_CPUS: u64 = 1 << 0;
+pub const ROOT_ZONE_ENTRY: u64 = 0x9000000000dc6000;
+pub const ROOT_ZONE_CPUS: u64 = (1 << 0) | (1 << 1);
 
 pub const ROOT_ZONE_NAME: &str = "root-linux-la64";
 
 pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
-    /* memory regions */
+    /* Legacy low RAM used during early boot. */
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x1000,
+        virtual_start: 0x0,
+        size: 0x10000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x10000,
+        virtual_start: 0x10000,
+        size: 0x1f0000,
+    },
+    /* Keep these banks aligned with the root Linux device tree. */
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
         physical_start: 0x00200000,
         virtual_start: 0x00200000,
-        size: 0x0ee00000,
-    }, // ram
+        size: 0x0ec00000,
+    },
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0x90000000,
-        virtual_start: 0x90000000,
-        size: 0x10000000,
-    }, // ram
+        physical_start: 0x90400000,
+        virtual_start: 0x90400000,
+        size: 0x67b60000,
+    },
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0xf000_0000,
-        virtual_start: 0xf000_0000,
-        size: 0x1000_0000,
-    }, // ram
+        physical_start: 0xf7f70000,
+        virtual_start: 0xf7f70000,
+        size: 0x05f10000,
+    },
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0x1_6000_0000,
-        virtual_start: 0x1_6000_0000,
-        size: 0x1000_0000,
-    }, // linux0
+        physical_start: 0xfe440000,
+        virtual_start: 0xfe440000,
+        size: 0xf1bc0000,
+    },
+    /* Shared-memory and non-root banks reserved by the root device tree. */
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0xc000_0000,
-        virtual_start: 0xc000_0000,
-        size: 0x3000_0000,
-    }, // linux1
+        physical_start: 0x2_00c0_0000,
+        virtual_start: 0x2_00c0_0000,
+        size: 0x0400_0000,
+    },
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0xa000_0000,
-        virtual_start: 0xa000_0000,
-        size: 0x2000_0000,
-    }, // linux2
+        physical_start: 0x2_04c0_0000,
+        virtual_start: 0x2_04c0_0000,
+        size: 0x0400_0000,
+    },
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_RAM,
-        physical_start: 0x1_0000_0000,
-        virtual_start: 0x1_0000_0000,
-        size: 0x2000_0000,
-    }, // linux3
+        physical_start: 0x2_08c0_0000,
+        virtual_start: 0x2_08c0_0000,
+        size: 0x0400_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x2_0cc0_0000,
+        virtual_start: 0x2_0cc0_0000,
+        size: 0x0400_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x2_1cc0_0000,
+        virtual_start: 0x2_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x3_1cc0_0000,
+        virtual_start: 0x3_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x4_1cc0_0000,
+        virtual_start: 0x4_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x5_1cc0_0000,
+        virtual_start: 0x5_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x6_1cc0_0000,
+        virtual_start: 0x6_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_RAM,
+        physical_start: 0x7_1cc0_0000,
+        virtual_start: 0x7_1cc0_0000,
+        size: 0x1_0000_0000,
+    },
     /* devices and controllers */
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_IO,
         physical_start: 0x1fe00000,
         virtual_start: 0x1fe00000,
-        size: 0x1000,
-    }, // uart0
+        size: 0x3000,
+    }, // IOCSR MMIO: uart0, IPI, EXTIOI.
+    // Reference:
+    //  IPI: <https://loongson.github.io/LoongArch-Documentation/Loongson-3A5000-usermanual-EN.html#accessing-by-address-3>
+    //  EXTIOI: <https://loongson.github.io/LoongArch-Documentation/Loongson-3A5000-usermanual-EN.html#accessing-by-address-5>
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_IO,
         physical_start: 0x10080000,
@@ -97,6 +156,18 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
         virtual_start: 0x10000000,
         size: 0x1000,
     }, // pch-pic irq controller
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_IO,
+        physical_start: 0x100A_0000,
+        virtual_start: 0x100A_0000,
+        size: 0x1000,
+    }, // LS7A PWM0-3
+    HvConfigMemoryRegion {
+        mem_type: MEM_TYPE_IO,
+        physical_start: 0x0E0010000000,
+        virtual_start: 0x0E0010000000,
+        size: 0x1000,
+    }, // ACPI thermal sensor
     /* PCI related stuffs ... */
     // HvConfigMemoryRegion {
     //     mem_type: MEM_TYPE_IO,
@@ -115,40 +186,25 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
     //     physical_start: 0x18408000,
     //     virtual_start: 0x18408000,
     //     size: 0x00008000,
-    // }, // pci io resource
-    // HvConfigMemoryRegion {
-    //     mem_type: MEM_TYPE_IO,
-    //     physical_start: 0x60000000,
-    //     virtual_start: 0x60000000,
-    //     size: 0x20000000,
-    // }, // pci mem resource
+    // }, // pci config space (HT)
     HvConfigMemoryRegion {
         mem_type: MEM_TYPE_IO,
         physical_start: 0x1001_0000,
         virtual_start: 0x1001_0000,
         size: 0x0001_0000,
-    }, // ?
-    /* map special regions - 2024.4.12 */
-    // linux's strscpy called gpa at 0x9000_0000_0000_0000 which is ldx x, 0x9000_0000_0000_0000(a1) + 0x0(a0) why ?
-    // __memcpy_fromio 0xf0000 why?
+    }, // PCH/LS7A miscellaneous registers
     HvConfigMemoryRegion {
-        mem_type: MEM_TYPE_RAM,
-        physical_start: 0x1000,
-        virtual_start: 0x0,
-        size: 0x10000,
-    }, // 0x0
+        mem_type: MEM_TYPE_IO,
+        physical_start: 0x18408000,
+        virtual_start: 0x18408000,
+        size: 0x00008000,
+    }, // PCI IO resource
     HvConfigMemoryRegion {
-        mem_type: MEM_TYPE_RAM,
-        physical_start: 0xf0000,
-        virtual_start: 0xf0000,
-        size: 0x10000,
-    }, // 0xf0000
-    HvConfigMemoryRegion {
-        mem_type: MEM_TYPE_RAM,
-        physical_start: 0x1_4000_0000,
-        virtual_start: 0x1_4000_0000,
-        size: 0x80_0000, // linux1-root
-    }, // SHARD_MEM
+        mem_type: MEM_TYPE_IO,
+        physical_start: 0x60000000,
+        virtual_start: 0x60000000,
+        size: 0x20000000,
+    }, // PCI memory resource
 ];
 
 pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;
@@ -158,7 +214,7 @@ pub const ROOT_ZONE_IVC_CONFIG: [HvIvcConfig; 0] = [];
 
 pub const ROOT_PCI_CONFIG: [HvPciConfig; 1] = [HvPciConfig {
     bus_range_begin: 0x0,
-    bus_range_end: 0x1f,
+    bus_range_end: 0xff,
     ecam_base: 0xfe00000000,
     ecam_size: 0x20000000,
     io_base: 0x18408000,

--- a/platform/loongarch64/ls3a6000/configs/zone1-linux.json
+++ b/platform/loongarch64/ls3a6000/configs/zone1-linux.json
@@ -3,32 +3,15 @@
     "name": "linux1",
     "zone_id": 1,
     "cpus": [
-        1
+        2,
+        3
     ],
     "memory_regions": [
         {
             "type": "ram",
-            "physical_start": "0xc0000000",
-            "virtual_start": "0xc0000000",
-            "size": "0x10000000"
-        },
-        {
-            "type": "ram",
-            "physical_start": "0xd0000000",
-            "virtual_start": "0xd0000000",
-            "size": "0x10000000"
-        },
-        {
-            "type": "io",
-            "physical_start": "0x1fe00000",
-            "virtual_start": "0x1fe00000",
-            "size": "0x1000"
-        },
-        {
-            "type": "io",
-            "physical_start": "0x10080000",
-            "virtual_start": "0x10080000",
-            "size": "0x1000"
+            "physical_start": "0x21cc00000",
+            "virtual_start": "0x21cc00000",
+            "size": "0x200000000"
         },
         {
             "type": "virtio",
@@ -41,30 +24,6 @@
             "physical_start": "0x30002000",
             "virtual_start": "0x30002000",
             "size": "0x200"
-        },
-        {
-            "type": "io",
-            "physical_start": "0xffffffff0000",
-            "virtual_start": "0xffffffff0000",
-            "size": "0x1000"
-        },
-        {
-            "type": "io",
-            "physical_start": "0x10000000",
-            "virtual_start": "0x10000000",
-            "size": "0x1000"
-        },
-        {
-            "type": "io",
-            "physical_start": "0x100d0000",
-            "virtual_start": "0x100d0000",
-            "size": "0x1000"
-        },
-        {
-            "type": "io",
-            "physical_start": "0x10010000",
-            "virtual_start": "0x10010000",
-            "size": "0x00010000"
         },
         {
             "type": "ram",
@@ -80,34 +39,49 @@
         },
         {
             "type": "ram",
-            "physical_start": "0x140000000",
-            "virtual_start": "0x140000000",
-            "size": "0x800000"
+            "physical_start": "0x200c00000",
+            "virtual_start": "0x200c00000",
+            "size": "0x04000000"
         },
         {
             "type": "ram",
-            "physical_start": "0x140800000",
-            "virtual_start": "0x140800000",
-            "size": "0x800000"
+            "physical_start": "0x204c00000",
+            "virtual_start": "0x204c00000",
+            "size": "0x04000000"
         },
         {
             "type": "ram",
-            "physical_start": "0x141000000",
-            "virtual_start": "0x141000000",
-            "size": "0x800000"
+            "physical_start": "0x210c00000",
+            "virtual_start": "0x210c00000",
+            "size": "0x04000000"
+        },
+        {
+            "type": "ram",
+            "physical_start": "0x214c00000",
+            "virtual_start": "0x214c00000",
+            "size": "0x04000000"
         }
     ],
     "interrupts": [
         4,
         5
     ],
-    "ivc_configs": [],
+    "ivc_configs": [{
+        "ivc_id": 0,
+        "peer_id": 1,
+        "control_table_ipa": "0x200be0000",
+        "shared_mem_ipa": "0x200be1000",
+        "rw_sec_size": 0,
+        "out_sec_size": "0x1000",
+        "interrupt_num": 148,
+        "max_peers": 2
+    }],
     "kernel_args": "NOT_USED_YET",
     "kernel_filepath": "/tool/nonroot/vmlinux-linux1.bin",
     "dtb_filepath": "/tool/test.bin",
-    "kernel_load_paddr": "0xc0200000",
-    "dtb_load_paddr": "0xc0000000",
-    "entry_point": "0x90000000c0dff000",
+    "kernel_load_paddr": "0x21ce00000",
+    "dtb_load_paddr": "0x21cc00000",
+    "entry_point": "0x900000021da22000",
     "arch_config": {
         "dummy": "0x1234"
     },
@@ -120,22 +94,22 @@
         "mem32_base": "0x0",
         "mem32_size": "0x0",
         "pci_mem32_base": "0x0",
-        "mem64_base": "0x60000000",
-        "mem64_size": "0x20000000",
-        "pci_mem64_base": "0x60000000",
-        "bus_range_begin": "0x0",
-        "bus_range_end": "0x1f",
+        "mem64_base": "0x75300000",
+        "mem64_size": "0x1000000",
+        "pci_mem64_base": "0x75300000",
+        "bus_range_begin": "0x6",
+        "bus_range_end": "0x6",
         "domain": "0x0"
     }],
     "num_pci_devs": 1,
     "alloc_pci_devs": [{
         "domain": "0x0",
         "bus": "0x6",
-        "device": "0x1",
-        "function": "0x0",
+        "device": "0x0",
+        "function": "0x1",
         "v_bus": "0x6",
-        "v_device": "0x1",
-        "v_function": "0x0",
+        "v_device": "0x0",
+        "v_function": "0x1",
         "dev_type": "0"
     }]
 }

--- a/platform/loongarch64/ls3a6000/image/dts/include/loongson-3a5000.dtsi
+++ b/platform/loongarch64/ls3a6000/image/dts/include/loongson-3a5000.dtsi
@@ -21,6 +21,14 @@
 			next-level-cache = <&scache0>;
 			numa-node-id = <0>;
 		};
+		cpu@1 {
+			compatible = "loongson,loongson3";
+			device_type = "cpu";
+			reg = <0x1>;
+			l2-cache = <&vcache1>;
+			next-level-cache = <&scache0>;
+			numa-node-id = <0>;
+		};
 		vcache0: l2-cache0 {
 			compatible = "cache";
 			next-level-cache = <&scache0>;

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -28,9 +28,15 @@ use crate::{memory::addr::VirtAddr, platform::BOARD_NCPUS};
 use core::arch::global_asm;
 
 /// Size of the hypervisor heap.
+#[cfg(loongson_3a6000)]
+pub const HV_HEAP_SIZE: usize = 8 * 1024 * 1024; // 8 MiB
+#[cfg(not(loongson_3a6000))]
 pub const HV_HEAP_SIZE: usize = 1024 * 1024; // 1 MiB
 
-/// Size of the hypervisor memory pool used for dynamic allocation.
+/// Size of the hypervisor memory pool used for dynamic stage-2 page tables.
+#[cfg(loongson_3a6000)]
+pub const HV_MEM_POOL_SIZE: usize = 0x1000_0000; // 256 MiB
+#[cfg(not(loongson_3a6000))]
 pub const HV_MEM_POOL_SIZE: usize = 64 * 1024 * 1024; // 64 MiB
 
 /// Size of the per-CPU data area, including stack and CPU-local data.


### PR DESCRIPTION
## Summary

Update the LoongArch platform configuration to support an SMP root zone and an SMP non-root Linux zone on the Loongson 3A6000 board.

## Changes

### Hypervisor memory pools

Increase the 3A6000-specific hypervisor heap from 1 MiB to 8 MiB and the stage-2 page-table memory pool from 64 MiB to 256 MiB. Other platforms retain their existing memory sizes.

### Loongson 3A5000 IOCSR mapping

Expand the IOCSR MMIO region from `0x1fe00000-0x1fe00fff` to `0x1fe00000-0x1fe02fff` so that the root zone can access the UART, IPI, and EXTIOI registers.

### Loongson 3A6000 root zone

- Correct the board name and root Linux entry point.
- Assign physical CPUs 0 and 1 to the root zone and add CPU 1 to the root Linux device tree.
- Align the RAM layout with the root Linux device tree, including the memory reserved for the non-root zone and IVC.
- Map the required LS7A, PCI I/O, PCI memory, PWM, and thermal sensor regions.
- Extend root-zone PCI enumeration to the full bus range.

### Loongson 3A6000 linux1 zone

- Assign physical CPUs 2 and 3 to `linux1`.
- Use the 3A6000 high-memory layout and update the kernel, DTB, and entry-point addresses.
- Configure the IVC shared-memory channel.
- Pass through PCI device `0000:06:00.1` with an identity virtual BDF.
- Limit PCI enumeration to bus 6 and use the device's `0x75300000` PCI memory window.

## CPU layout

| Zone | Physical CPUs | Guest CPUs |
| --- | --- | --- |
| Root Linux | 0, 1 | 0, 1 |
| linux1 | 2, 3 | 0, 1 |

## PCI layout

The root zone retains `0000:06:00.0`, while `linux1` receives `0000:06:00.1`. The non-root zone exposes the device using the same virtual BDF and limits PCI enumeration to bus 6.
