### PR TITLE
ci: restore manual workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
   #   branches:
   #     - main
   #     - dev
-  # workflow_dispatch:
+  workflow_dispatch:
 env:
   MODE: debug
 jobs:


### PR DESCRIPTION
## Summary

- restore `workflow_dispatch` as the GitHub Actions trigger
- keep push and pull request triggers disabled
- prevent the empty `on:` mapping from producing invalid workflow runs

## Validation

- `actionlint .github/workflows/ci.yml`
- `npx --yes yaml-lint .github/workflows/ci.yml`
- `git diff --check`