### PR TITLE
ci(x86_64): add Asterinas zone1 Jenkins test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,11 @@ def parseBid(String bid) {
     return [arch: parts[0], board: parts[1]]
 }
 
+/** Optional platform_board in ci.yaml maps BID board to make/platform board. */
+def platformBoard(String bid, String configuredBoard = '') {
+    return configuredBoard ?: parseBid(bid).board
+}
+
 def parseCiBuildArgs(cfg) {
     def buildArgs = [:]
     if (!cfg?.build_args) {
@@ -173,7 +178,7 @@ def kconfigSetupShell(String arch, String board) {
             mkdir -p tools/kconfig
             ln -sfn ${env.KCONFIG_VENV} tools/kconfig/.venv
         fi
-        make defconfig ARCH=${arch} BOARD=${board}
+        make defconfig ARCH=${arch} BOARD=${board} BID=
     """
 }
 
@@ -277,6 +282,7 @@ pipeline {
                             'x86_64/ecx-2300f-peg',
                             'x86_64/nuc14mnk',
                             'x86_64/qemu',
+                            'x86_64/qemu_asterinas',
                         )
                     }
                 }
@@ -297,18 +303,20 @@ pipeline {
                                 script {
                                     def bid = parseBid(env.BID)
                                     def arch = bid.arch
-                                    def board = bid.board
+                                    // BID may name a test variant (qemu_asterinas); platform_board selects the actual make/platform board (qemu).
+                                    def bidCfg = getBidConfig(loadCiYaml(), env.BID)
+                                    def board = platformBoard(env.BID, bidCfg?.platform_board?.toString() ?: '')
                                     echo "Compile hvisor [BID=${env.BID}, ARCH=${arch}, BOARD=${board}]"
                                     sh kconfigSetupShell(arch, board)
                                     if (arch != 'x86_64') {
                                         sh """
                                             ${toolchainPathShell()}
-                                            make dtb ARCH=${arch} BOARD=${board}
+                                            make dtb ARCH=${arch} BOARD=${board} BID=
                                         """
                                     }
                                     sh """
                                         ${toolchainPathShell()}
-                                        make all ARCH=${arch} BOARD=${board} MODE=release
+                                        make all ARCH=${arch} BOARD=${board} MODE=release BID=
                                     """
                                 }
                             }
@@ -363,9 +371,11 @@ pipeline {
                                     def buildArgs = parseCiBuildArgs(bidCfg)
                                     def bidParsed = parseBid(env.BID)
                                     def arch = bidParsed.arch
-                                    def board = bidParsed.board
+                                    // Keep the server artifact BID separate from the real platform board used by make and prepare.sh.
+                                    def board = platformBoard(env.BID, bidCfg?.platform_board?.toString() ?: '')
                                     def kdir = (buildArgs.KDIR ?: '').toString()
                                     def testsCfg = bidCfg.tests ?: [:]
+                                    def artifactDir = testsCfg.artifact_dir ?: bidParsed.board
                                     def mode = (testsCfg.mode ?: '').toString().trim()
                                     if (!kdir || !mode) {
                                         error("jenkins/ci.yaml BID=${env.BID}: tests.mode and build_args KDIR are required")
@@ -373,11 +383,17 @@ pipeline {
 
                                     if (mode == 'qemu') {
                                         def prepareScript = "jenkins/prepare.sh"
-                                        def externalFile = "${env.TEST_IMG_BASE}/${arch}/${board}"
+                                        def externalFile = "${env.TEST_IMG_BASE}/${arch}/${artifactDir}"
                                         def configure = "./platform/${arch}/${board}/"
                                         echo "Prepare rootfs [BID=${env.BID}]"
                                         sh """
                                             cp -r ${externalFile}/* ${configure}
+                                            if [ "${artifactDir}" != "${board}" ]; then
+                                                mkdir -p "${configure}/image/kernel" "${configure}/image/virtdisk"
+                                                cp "${env.TEST_IMG_BASE}/${arch}/${board}/image/kernel/setup.bin" "${configure}/image/kernel/setup.bin"
+                                                cp "${env.TEST_IMG_BASE}/${arch}/${board}/image/kernel/vmlinux.bin" "${configure}/image/kernel/vmlinux.bin"
+                                                cp "${env.TEST_IMG_BASE}/${arch}/${board}/image/virtdisk/rootfs1.img" "${configure}/image/virtdisk/rootfs1.img"
+                                            fi
                                             chmod +x "${prepareScript}"
                                             sudo -E env \\
                                                 ARCH="${arch}" \\

--- a/jenkins/ci.yaml
+++ b/jenkins/ci.yaml
@@ -102,3 +102,14 @@ bids:
       cases:
         - zone0_start
         - zone1_start
+
+  - bid: x86_64/qemu_asterinas
+    platform_board: qemu
+    build_args:
+      - KDIR=/home/light/DEMO/linux/linux-5.19
+    tests:
+      mode: qemu
+      artifact_dir: qemu_asterinas
+      cases:
+        - zone0_start
+        - asterinas_zone1_regression

--- a/jenkins/ci_config.py
+++ b/jenkins/ci_config.py
@@ -67,6 +67,7 @@ def get_bid_entry(data: dict[str, Any], bid: str) -> dict[str, Any]:
                 raise RuntimeError(f"{bid}: tests.cases must be a list")
             return {
                 "bid": bid,
+                "platform_board": str(entry.get("platform_board") or "").strip(),
                 "build_args": build_args,
                 "mode": mode,
                 "cases": [str(x) for x in cases if str(x).strip()],

--- a/jenkins/ci_runner.py
+++ b/jenkins/ci_runner.py
@@ -29,6 +29,10 @@ from terminal import Terminal, TerminalCommandError, TerminalTimeoutError
 CaseFunc = Callable[[dict[str, Any], Terminal | None], int]
 
 
+def platform_board(board: str, configured: str = "") -> str:
+    return configured.strip() or board
+
+
 def wait_qemu_socket(path: str, timeout: float = 30.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -142,7 +146,9 @@ def zone0_start(cfg: dict[str, Any], term: Terminal | None) -> int:
     print("————————————————\ncase: zone0_start\n————————————————\n", flush=True)
     if cfg["mode"] == "qemu":
         cmd = ["make", f"ARCH={cfg['arch']}", f"BOARD={cfg['board']}", "MODE=release", "ci-run"]
-        proc = subprocess.Popen(cmd, cwd=cfg["workspace"], start_new_session=True)
+        env = os.environ.copy()
+        env["BID"] = ""
+        proc = subprocess.Popen(cmd, cwd=cfg["workspace"], start_new_session=True, env=env)
         cfg["_managed_proc"] = proc
         wait_qemu_socket(cfg["socket_path"], timeout=30.0)
         with build_terminal(cfg) as qemu_term:
@@ -158,7 +164,7 @@ def zone0_start(cfg: dict[str, Any], term: Terminal | None) -> int:
                     qemu_term.send(uboot)
                 else:
                     qemu_term.send("bootm 0x40400000 - 0x40000000")
-            if bid == "x86_64/qemu":
+            if bid in ("x86_64/qemu", "x86_64/qemu_asterinas"):
                 time.sleep(10.0)
             _ = read_and_print_until_quiet(
                 qemu_term,
@@ -234,11 +240,85 @@ def zone1_start(cfg: dict[str, Any], term: Terminal | None) -> int:
     return 0
 
 
+def asterinas_zone1_regression(cfg: dict[str, Any], term: Terminal | None) -> int:
+    print("————————————————\ncase: asterinas_zone1_regression\n————————————————\n", flush=True)
+    if term is None:
+        raise SystemExit("terminal backend is required")
+
+    _, _ = run_and_print_quiet(term, "cd /root", quiet_seconds=1.0, max_duration=15.0)
+    _, _ = run_and_print_quiet(
+        term,
+        "cat boot_zone1_asterinas.sh",
+        quiet_seconds=1.0,
+        max_duration=15.0,
+    )
+    _, _ = run_and_print_quiet(
+        term,
+        "bash boot_zone1_asterinas.sh",
+        quiet_seconds=15,
+        max_duration=45.0,
+    )
+    zone_list_out, _ = run_and_print_quiet(
+        term,
+        "./hvisor zone list",
+        quiet_seconds=1.0,
+        max_duration=15.0,
+        check_exit=False,
+    )
+    zone_list_shows_running(zone_list_out, "asterinas")
+
+    pts_output, _ = run_and_print_quiet(
+        term,
+        "ls -1 /dev/pts/[0-9]*",
+        quiet_seconds=1.0,
+        max_duration=15.0,
+    )
+    pts_numbers = sorted(int(match) for match in re.findall(r"/dev/pts/(\d+)", pts_output))
+    if not pts_numbers:
+        raise TerminalCommandError("failed to find numeric pts from 'ls -1 /dev/pts/[0-9]*'")
+    max_pts = pts_numbers[-1]
+
+    _ = run_and_print_send_only(term, f"screen /dev/pts/{max_pts}", read_duration=20.0)
+    _ = read_and_print_until_quiet(term, quiet_seconds=3.0, max_duration=30.0)
+
+    regression_marker = "__HV_REGRESSION_RC_"
+    term.send_one_by_one(f"/test/run_regression_test.sh; echo {regression_marker}$?")
+    output = ""
+    deadline = time.monotonic() + 900.0
+    while time.monotonic() < deadline:
+        chunk = term.read_for(duration=2.0)
+        if not chunk:
+            continue
+        output += chunk
+        print(chunk, end="", flush=True)
+
+        rc_match = re.search(re.escape(regression_marker) + r"(\d+)", output)
+        if rc_match is not None and rc_match.group(1) != "0":
+            raise TerminalCommandError(
+                f"Asterinas regression exited with rc={rc_match.group(1)}"
+            )
+        if rc_match is not None and "All regression tests passed" in output:
+            break
+    if "All regression tests passed" not in output:
+        raise TerminalCommandError("Asterinas regression completion marker not found")
+
+    # Ctrl-A d detaches from GNU screen; Ctrl-A Ctrl-A d is not a detach.
+    term.backend.write(b"\x01d")
+    time.sleep(1.0)
+    term.backend.write(b"\r")
+    detach_output = read_and_print_until_quiet(term, quiet_seconds=2.0, max_duration=10.0)
+    if "root@zone0" not in detach_output:
+        raise TerminalCommandError("failed to return to zone0 after screen detach")
+    print("asterinas_zone1_regression_passed", flush=True)
+    return 0
+
+
 CASE_HANDLERS: dict[str, CaseFunc] = {
     "zone0_start": zone0_start,
     "login": login,
     "network_and_trans": network_and_trans,
     "zone1_start": zone1_start,
+    "asterinas_zone1_regression": asterinas_zone1_regression,
 }
 
 
@@ -257,9 +337,10 @@ def load_runtime_config(args: argparse.Namespace) -> dict[str, Any]:
         deploy = {}
 
     try:
-        arch, board = parse_bid(args.bid)
+        arch, bid_board = parse_bid(args.bid)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
+    board = platform_board(bid_board, bid_entry.get("platform_board", ""))
     mode = bid_entry.get("mode", "").strip()
     cases = bid_entry.get("cases", [])
     if not mode:

--- a/jenkins/prepare.sh
+++ b/jenkins/prepare.sh
@@ -24,7 +24,16 @@ ROOTFS_IMG=""
 ZONE1_DTB="${IMAGE_DIR}/dts/zone1-linux.dtb"
 ZONE1_DTS_DIR="${IMAGE_DIR}/dts"
 ZONE1_BOOT_SCRIPT="${SCRIPTS_DIR}/boot_zone1.sh"
+ZONE1_ASTERINAS_BOOT_SCRIPT="${SCRIPTS_DIR}/boot_zone1_asterinas.sh"
 KERNEL_IMAGE=""
+
+# Asterinas CI artifacts follow the qemu_asterinas layout:
+#   image/kernel/aster-kernel-osdk-bin
+#   image/virtdisk/initramfs.cpio.gz
+# ASTERINAS_KERNEL/ASTERINAS_INITRAMFS override these for local validation.
+ASTERINAS_KERNEL_DEFAULT="${IMAGE_DIR}/kernel/aster-kernel-osdk-bin"
+ASTERINAS_INITRAMFS_DEFAULT="${VIRTDISK_DIR}/initramfs.cpio.gz"
+ZONE1_DISK_SIZE_MB="${ZONE1_DISK_SIZE_MB:-512}"
 
 case "${ARCH}" in
     x86_64)
@@ -87,6 +96,35 @@ if [ "${ARCH}" = "x86_64" ]; then
     cp "${JUMP}" "${ROOTFS_DIR}/root/"
 fi
 
+if [ -n "${ASTERINAS_KERNEL:-}" ] || [ -f "${ASTERINAS_KERNEL_DEFAULT}" ] ||
+    [ -n "${ASTERINAS_INITRAMFS:-}" ] || [ -f "${ASTERINAS_INITRAMFS_DEFAULT}" ]; then
+    ASTERINAS_KERNEL="${ASTERINAS_KERNEL:-${ASTERINAS_KERNEL_DEFAULT}}"
+    ASTERINAS_INITRAMFS="${ASTERINAS_INITRAMFS:-${ASTERINAS_INITRAMFS_DEFAULT}}"
+    if [ ! -f "${ASTERINAS_KERNEL}" ]; then
+        echo "error: Asterinas kernel not found: ${ASTERINAS_KERNEL}"
+        exit 1
+    fi
+    if [ ! -f "${ASTERINAS_INITRAMFS}" ]; then
+        echo "error: Asterinas initramfs not found: ${ASTERINAS_INITRAMFS}"
+        exit 1
+    fi
+    cp "${ASTERINAS_KERNEL}" "${ROOTFS_DIR}/root/aster-kernel-osdk-bin"
+    cp "${ASTERINAS_INITRAMFS}" "${ROOTFS_DIR}/root/initramfs.cpio.gz"
+
+    MB2_BOOT="${IMAGE_DIR}/mb2_bootloader/out/mb2_boot.bin"
+    if [ -f "${MB2_BOOT}" ]; then
+        cp "${MB2_BOOT}" "${ROOTFS_DIR}/root/"
+    else
+        echo "error: Multiboot2 bootloader not found: ${MB2_BOOT}"
+        exit 1
+    fi
+
+    ZONE1_DISK="${ROOTFS_DIR}/zone1_disk.img"
+    rm -f "${ZONE1_DISK}"
+    truncate -s "${ZONE1_DISK_SIZE_MB}M" "${ZONE1_DISK}"
+    mkfs.ext2 -F -b 4096 "${ZONE1_DISK}"
+fi
+
 if [ "${ARCH}" != "x86_64" ]; then
     if [ ! -f "${ZONE1_DTB}" ]; then
         if [ -d "${ZONE1_DTS_DIR}" ]; then
@@ -105,9 +143,15 @@ if [ "${ARCH}" != "x86_64" ]; then
 fi
 
 cp "${ZONE1_BOOT_SCRIPT}" "${ROOTFS_DIR}/root/"
+if [ -f "${ZONE1_ASTERINAS_BOOT_SCRIPT}" ]; then
+    cp "${ZONE1_ASTERINAS_BOOT_SCRIPT}" "${ROOTFS_DIR}/root/"
+fi
 
 if [ -f "${ROOTFS_DIR}/root/boot_zone1.sh" ]; then
     chmod +x "${ROOTFS_DIR}/root/boot_zone1.sh"
+fi
+if [ -f "${ROOTFS_DIR}/root/boot_zone1_asterinas.sh" ]; then
+    chmod +x "${ROOTFS_DIR}/root/boot_zone1_asterinas.sh"
 fi
 if [ -f "${ROOTFS_DIR}/root/screen_zone1.sh" ]; then
     chmod +x "${ROOTFS_DIR}/root/screen_zone1.sh"

--- a/jenkins/terminal.py
+++ b/jenkins/terminal.py
@@ -392,6 +392,23 @@ class Terminal:
         payload = command.rstrip("\n") + "\n"
         self.backend.write(payload.encode(self.encoding, errors="replace"))
 
+    def send_one_by_one(
+        self,
+        command: str,
+        char_delay: float = 0.02,
+    ) -> None:
+        """Send a command one character at a time for lossy consoles.
+
+        Asterinas' virtio-console currently consumes one byte per interrupt, so
+        pasting a complete command can drop characters. This helper keeps the
+        command readable while avoiding that loss.
+        """
+        self._ensure_open()
+        for char in command.rstrip("\n"):
+            self.backend.write(char.encode(self.encoding, errors="replace"))
+            time.sleep(char_delay)
+        self.backend.write(b"\n")
+
     def read_for(
         self,
         duration: float = 2.0,

--- a/platform/x86_64/qemu/scripts/boot_zone1_asterinas.sh
+++ b/platform/x86_64/qemu/scripts/boot_zone1_asterinas.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+insmod hvisor.ko
+nohup ./hvisor virtio start virtio_cfg_asterinas.json &
+sleep 3
+./hvisor zone start ./zone1-asterinas.json


### PR DESCRIPTION
## Motivation

Add Asterinas zone1 coverage to the existing x86_64 QEMU Jenkins CI while keeping `x86_64/qemu` as the Linux zone1 test flow.

## Approach

Use a dedicated `x86_64/qemu_asterinas` BID for Asterinas instead of mixing Linux and Asterinas in the same BID. The existing `x86_64/qemu` BID remains unchanged and only tests Linux zone1.

`platform_board: qemu` decouples the Jenkins BID from the make/platform board:

- BID `x86_64/qemu_asterinas` is only a test identity and server artifact directory.
- make still uses the real platform `BOARD=qemu` because `platform/x86_64/qemu_asterinas` does not exist in the source tree.
- `artifact_dir: qemu_asterinas` selects the Asterinas artifact directory.

## Artifact layout

`qemu_asterinas` provides:

- `image/kernel/aster-kernel-osdk-bin`
- `image/virtdisk/initramfs.cpio.gz`

The shared `x86_64/qemu` artifacts still provide zone0 files:

- `image/kernel/setup.bin`
- `image/kernel/vmlinux.bin`
- `image/virtdisk/rootfs1.img`

## Changes

- `Jenkinsfile`: add `platform_board` parsing and the `x86_64/qemu_asterinas` matrix cell.
- `jenkins/ci.yaml`: add the dedicated BID and keep Linux zone1 in `x86_64/qemu`.
- `jenkins/ci_config.py`: expose optional `platform_board`.
- `jenkins/ci_runner.py`: map BID to the real platform board, clear `BID` for hvisor make, and add `asterinas_zone1_regression`.
- `jenkins/prepare.sh`: deploy Asterinas kernel/initramfs, Multiboot2 bootloader, and create `zone1_disk.img` with `mkfs.ext2 -b 4096`.
- `jenkins/terminal.py`: add `send_one_by_one()` for sensitive guest consoles.
- `platform/x86_64/qemu/scripts/boot_zone1_asterinas.sh`: start Asterinas zone1 with the Asterinas virtio config.

## QEMU lifecycle

Each BID starts one QEMU instance and runs its own test cases. There is no Linux/Asterinas state sharing and no restart between two guest types inside one BID.

## Verification

- `x86_64/qemu` passes Linux zone1 startup.
- `x86_64/qemu_asterinas` starts Asterinas zone1 and runs `/test/run_regression_test.sh`.
- CI polls Asterinas regression output until it sees both `All regression tests passed` and exit code 0; a non-zero regression exit fails immediately.
- After regression, CI sends `Ctrl-A d` to detach from the Asterinas screen and verifies the zone0 `root@zone0` prompt.
- Jenkins build 8 is fully green, including `x86_64/qemu_asterinas`.