### PR TITLE
feat: add hypercall to query ECAM base

### DIFF
--- a/src/arch/aarch64/hypercall.rs
+++ b/src/arch/aarch64/hypercall.rs
@@ -24,6 +24,10 @@ use crate::hypercall::HyperCallResult;
 use crate::zone::this_zone_id;
 
 impl<'a> HyperCall<'a> {
+    pub fn hv_get_ecam_base(&mut self, _ecam_base: *mut u64) -> HyperCallResult {
+        HyperCallResult::Ok(0)
+    }
+
     pub fn hv_ivc_info(&mut self, ivc_info_ipa: u64) -> HyperCallResult {
         let zone_id = this_zone_id();
         let zone = this_zone();

--- a/src/arch/loongarch64/hypercall.rs
+++ b/src/arch/loongarch64/hypercall.rs
@@ -21,6 +21,10 @@ use crate::device::virtio_trampoline::MAX_DEVS;
 use crate::hypercall::HyperCall;
 use crate::hypercall::HyperCallResult;
 impl<'a> HyperCall<'a> {
+    pub fn hv_get_ecam_base(&mut self, _ecam_base: *mut u64) -> HyperCallResult {
+        HyperCallResult::Ok(0)
+    }
+
     pub fn hv_ivc_info(&mut self, ivc_info_ipa: u64) -> HyperCallResult {
         warn!("hv_ivc_info is not implemented for LoongArch64");
         HyperCallResult::Ok(0)

--- a/src/arch/riscv64/hypercall.rs
+++ b/src/arch/riscv64/hypercall.rs
@@ -21,6 +21,10 @@ use crate::hypercall::HyperCall;
 use crate::hypercall::HyperCallResult;
 
 impl<'a> HyperCall<'a> {
+    pub fn hv_get_ecam_base(&mut self, _ecam_base: *mut u64) -> HyperCallResult {
+        HyperCallResult::Ok(0)
+    }
+
     pub fn hv_ivc_info(&mut self, _ivc_info_ipa: u64) -> HyperCallResult {
         warn!("hv_ivc_info is not implemented for Risc-V");
         HyperCallResult::Ok(0)

--- a/src/arch/x86_64/hypercall.rs
+++ b/src/arch/x86_64/hypercall.rs
@@ -25,6 +25,18 @@ use crate::{
 use spin::RwLock;
 
 impl<'a> HyperCall<'a> {
+    pub fn hv_get_ecam_base(&mut self, ecam_base: *mut u64) -> HyperCallResult {
+        let ecam_base_pa = self.hv_get_real_pa(ecam_base as u64);
+        let base = crate::arch::acpi::root_get_config_space_info()
+            .map(|(base, _)| base as u64)
+            .unwrap_or(0);
+        unsafe {
+            *(ecam_base_pa as *mut u64) = base;
+        }
+        debug!("hvisor ecam base: {:#x}", base);
+        HyperCallResult::Ok(0)
+    }
+
     pub fn hv_ivc_info(&mut self, ivc_info_ipa: u64) -> HyperCallResult {
         warn!("hv_ivc_info is not implemented for x86_64");
         HyperCallResult::Ok(0)

--- a/src/hypercall/mod.rs
+++ b/src/hypercall/mod.rs
@@ -53,6 +53,7 @@ numeric_enum! {
         HvConfigCheck = 6,
         HvVirtioPCI = 7,
         HvZoneSetBootMode = 8,
+        HvGetEcamBase = 9,
     }
 }
 pub const SGI_IPI_ID: u64 = 7;
@@ -105,6 +106,7 @@ impl<'a> HyperCall<'a> {
                 HyperCallCode::HvConfigCheck => self.hv_zone_config_check(arg0 as *mut u64),
                 HyperCallCode::HvVirtioPCI => self.hv_virtio_pci(arg0, arg1),
                 HyperCallCode::HvZoneSetBootMode => self.hv_zone_set_boot_mode(arg0, arg1),
+                HyperCallCode::HvGetEcamBase => self.hv_get_ecam_base(arg0 as *mut u64),
                 _ => {
                     warn!("hypercall id={} unsupported!", code as u64);
                     Ok(0)


### PR DESCRIPTION
## Motivation

ECAM base can differ across x86_64 devices. hvisor already parses ACPI MCFG, but hvisor-tool needs a way to obtain the correct base before constructing the zone configuration.

## Changes

- `src/hypercall/mod.rs`: add `HvGetEcamBase = 9` hypercall and dispatch it.
- `src/arch/x86_64/hypercall.rs`: implement `hv_get_ecam_base()` to write the ACPI MCFG ECAM base into the caller-provided address.
- aarch64/riscv64/loongarch64 hypercall files: add a no-op handler returning 0 so the shared hypercall dispatch compiles.

## hvisor-tool

hvisor-tool queries this hypercall before starting a zone and overrides `pci_config[0].ecam_base`. See https://github.com/syswonder/hvisor-tool/pull/115.

## Verification

- hvisor x86_64 build passes.
- Tested with zone JSON `ecam_base=0x12345000`; hvisor receives `0xe0000000` after hvisor-tool correction, Asterinas starts and the shell responds to `echo ci-ok`.