### PR TITLE
fix(loongarch64): Fix Virtio using too much CPU

### DIFF
--- a/platform/loongarch64/ls3a5000/board.rs
+++ b/platform/loongarch64/ls3a5000/board.rs
@@ -154,7 +154,7 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
     }, // SHARD_MEM
 ];
 
-pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;
+pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 4;
 pub const ROOT_ZONE_IRQS_BITMAP: &[BitmapWord] = &get_irqs_bitmap(&[]);
 pub const ROOT_ARCH_ZONE_CONFIG: HvArchZoneConfig = HvArchZoneConfig { dummy: 0 };
 pub const ROOT_ZONE_IVC_CONFIG: [HvIvcConfig; 0] = [];

--- a/platform/loongarch64/ls3a6000/board.rs
+++ b/platform/loongarch64/ls3a6000/board.rs
@@ -207,7 +207,7 @@ pub const ROOT_ZONE_MEMORY_REGIONS: &[HvConfigMemoryRegion] = &[
     }, // PCI memory resource
 ];
 
-pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 32 + 0x20;
+pub const IRQ_WAKEUP_VIRTIO_DEVICE: usize = 4;
 pub const ROOT_ZONE_IRQS_BITMAP: &[BitmapWord] = &get_irqs_bitmap(&[]);
 pub const ROOT_ARCH_ZONE_CONFIG: HvArchZoneConfig = HvArchZoneConfig { dummy: 0 };
 pub const ROOT_ZONE_IVC_CONFIG: [HvIvcConfig; 0] = [];

--- a/src/device/irqchip/ls7a2000/mod.rs
+++ b/src/device/irqchip/ls7a2000/mod.rs
@@ -113,11 +113,15 @@ static GUEST_HWI_ASSERTED: [AtomicU32; MAX_CPU_NUM] = {
     [C; MAX_CPU_NUM]
 };
 
-/// Serializes the software HWI bitmap with GINTC VIP updates for each pCPU.
-static GUEST_HWI_LOCKS: [Mutex<()>; MAX_CPU_NUM] = {
-    const L: Mutex<()> = Mutex::new(());
-    [L; MAX_CPU_NUM]
-};
+/// Serializes the software HWI bitmap with GINTC VIP updates for this pCPU.
+#[percpu::def_percpu]
+static GUEST_HWI_LOCK: Mutex<()> = Mutex::new(());
+
+// The caller ensures the cpu_id is valid.
+#[inline(always)]
+fn get_guest_hwi_lock(cpu: usize) -> &'static Mutex<()> {
+    unsafe { GUEST_HWI_LOCK.remote_ref_raw(cpu) }
+}
 
 fn sync_guest_irqs_unlocked(cpu: usize) {
     use crate::arch::register::gintc;
@@ -139,7 +143,7 @@ pub fn set_guest_irq_line(cpu: usize, irq: usize, asserted: bool) -> bool {
 
     let mask = 1u32 << (irq - INT_HWI0);
     let need_remote_sync = {
-        let _guard = GUEST_HWI_LOCKS[cpu].lock();
+        let _guard = get_guest_hwi_lock(cpu).lock();
         let state = &GUEST_HWI_ASSERTED[cpu];
         let old = state.load(Ordering::Relaxed);
         let new = if asserted { old | mask } else { old & !mask };
@@ -167,7 +171,7 @@ pub fn clear_guest_irq_lines(cpu: usize) {
         return;
     }
     let need_remote_sync = {
-        let _guard = GUEST_HWI_LOCKS[cpu].lock();
+        let _guard = get_guest_hwi_lock(cpu).lock();
         let old = GUEST_HWI_ASSERTED[cpu].swap(0, Ordering::Relaxed);
         if old == 0 {
             false
@@ -185,7 +189,7 @@ pub fn clear_guest_irq_lines(cpu: usize) {
 
 pub fn sync_guest_irqs() {
     let cpu = this_cpu_id();
-    let _guard = GUEST_HWI_LOCKS[cpu].lock();
+    let _guard = get_guest_hwi_lock(cpu).lock();
     sync_guest_irqs_unlocked(cpu);
 }
 

--- a/src/device/irqchip/ls7a2000/mod.rs
+++ b/src/device/irqchip/ls7a2000/mod.rs
@@ -30,6 +30,7 @@ use crate::{
 };
 use chip::*;
 use core::sync::atomic::{AtomicU32, Ordering};
+use spin::Mutex;
 
 pub mod chip;
 
@@ -112,6 +113,21 @@ static GUEST_HWI_ASSERTED: [AtomicU32; MAX_CPU_NUM] = {
     [C; MAX_CPU_NUM]
 };
 
+/// Serializes the software HWI bitmap with GINTC VIP updates for each pCPU.
+static GUEST_HWI_LOCKS: [Mutex<()>; MAX_CPU_NUM] = {
+    const L: Mutex<()> = Mutex::new(());
+    [L; MAX_CPU_NUM]
+};
+
+fn sync_guest_irqs_unlocked(cpu: usize) {
+    use crate::arch::register::gintc;
+    let desired_vip = GUEST_HWI_ASSERTED[cpu].load(Ordering::Relaxed) as usize & 0xff;
+    let old_vip = gintc::read().vip();
+    if old_vip != desired_vip {
+        gintc::write_vip(desired_vip);
+    }
+}
+
 pub fn set_guest_irq_line(cpu: usize, irq: usize, asserted: bool) -> bool {
     if cpu >= MAX_CPU_NUM || !(INT_HWI0..=INT_HWI7).contains(&irq) {
         error!(
@@ -122,20 +138,25 @@ pub fn set_guest_irq_line(cpu: usize, irq: usize, asserted: bool) -> bool {
     }
 
     let mask = 1u32 << (irq - INT_HWI0);
-    let state = &GUEST_HWI_ASSERTED[cpu];
-    let old = if asserted {
-        state.fetch_or(mask, Ordering::AcqRel)
-    } else {
-        state.fetch_and(!mask, Ordering::AcqRel)
+    let need_remote_sync = {
+        let _guard = GUEST_HWI_LOCKS[cpu].lock();
+        let state = &GUEST_HWI_ASSERTED[cpu];
+        let old = state.load(Ordering::Relaxed);
+        let new = if asserted { old | mask } else { old & !mask };
+        if old == new {
+            false
+        } else {
+            state.store(new, Ordering::Relaxed);
+            if cpu == this_cpu_id() {
+                sync_guest_irqs_unlocked(cpu);
+                false
+            } else {
+                true
+            }
+        }
     };
-    let new = if asserted { old | mask } else { old & !mask };
-    if old == new {
-        return true;
-    }
-
-    if cpu == this_cpu_id() {
-        sync_guest_irqs();
-    } else {
+    // Drop the lock before kicking the target; its handler takes the same lock.
+    if need_remote_sync {
         send_event(cpu, SGI_IPI_ID as usize, IPI_EVENT_VIRTIO_INJECT_IRQ);
     }
     true
@@ -145,25 +166,27 @@ pub fn clear_guest_irq_lines(cpu: usize) {
     if cpu >= MAX_CPU_NUM {
         return;
     }
-    let old = GUEST_HWI_ASSERTED[cpu].swap(0, Ordering::AcqRel);
-    if old == 0 {
-        return;
-    }
-    if cpu == this_cpu_id() {
-        sync_guest_irqs();
-    } else {
+    let need_remote_sync = {
+        let _guard = GUEST_HWI_LOCKS[cpu].lock();
+        let old = GUEST_HWI_ASSERTED[cpu].swap(0, Ordering::Relaxed);
+        if old == 0 {
+            false
+        } else if cpu == this_cpu_id() {
+            sync_guest_irqs_unlocked(cpu);
+            false
+        } else {
+            true
+        }
+    };
+    if need_remote_sync {
         send_event(cpu, SGI_IPI_ID as usize, IPI_EVENT_VIRTIO_INJECT_IRQ);
     }
 }
 
 pub fn sync_guest_irqs() {
     let cpu = this_cpu_id();
-    let desired_vip = GUEST_HWI_ASSERTED[cpu].load(Ordering::Acquire) as usize & 0xff;
-    use crate::arch::register::gintc;
-    let old_vip = gintc::read().vip();
-    if old_vip != desired_vip {
-        gintc::write_vip(desired_vip);
-    }
+    let _guard = GUEST_HWI_LOCKS[cpu].lock();
+    sync_guest_irqs_unlocked(cpu);
 }
 
 /// inject irq to THIS cpu

--- a/src/device/irqchip/ls7a2000/mod.rs
+++ b/src/device/irqchip/ls7a2000/mod.rs
@@ -29,7 +29,6 @@ use crate::{
     zone::Zone,
 };
 use chip::*;
-use core::sync::atomic::{AtomicU32, Ordering};
 use spin::Mutex;
 
 pub mod chip;
@@ -108,28 +107,35 @@ const INT_PERF: usize = 10;
 const INT_TIMER: usize = 11;
 const INT_IPI: usize = 12;
 
-static GUEST_HWI_ASSERTED: [AtomicU32; MAX_CPU_NUM] = {
-    const C: AtomicU32 = AtomicU32::new(0);
-    [C; MAX_CPU_NUM]
-};
-
-/// Serializes the software HWI bitmap with GINTC VIP updates for this pCPU.
+/// Per-pCPU software HWI bitmap, serialized with GINTC VIP updates.
 #[percpu::def_percpu]
-static GUEST_HWI_LOCK: Mutex<()> = Mutex::new(());
+static GUEST_HWI_ASSERTED: Mutex<u32> = Mutex::new(0);
 
 // The caller ensures the cpu_id is valid.
 #[inline(always)]
-fn get_guest_hwi_lock(cpu: usize) -> &'static Mutex<()> {
-    unsafe { GUEST_HWI_LOCK.remote_ref_raw(cpu) }
+fn get_guest_hwi_state(cpu: usize) -> &'static Mutex<u32> {
+    unsafe { GUEST_HWI_ASSERTED.remote_ref_raw(cpu) }
 }
 
-fn sync_guest_irqs_unlocked(cpu: usize) {
-    use crate::arch::register::gintc;
-    let desired_vip = GUEST_HWI_ASSERTED[cpu].load(Ordering::Relaxed) as usize & 0xff;
-    let old_vip = gintc::read().vip();
-    if old_vip != desired_vip {
-        gintc::write_vip(desired_vip);
+fn sync_guest_irqs_for_cpu(cpu: usize, update: impl FnOnce(&mut u32) -> bool) -> bool {
+    let mut state = get_guest_hwi_state(cpu).lock();
+    let changed = update(&mut state);
+
+    // GINTC.VIP is a per-CPU register, so only the local CPU can apply the
+    // bitmap immediately. Remote CPUs are kicked after the lock is released.
+    if cpu == this_cpu_id() {
+        use crate::arch::register::gintc;
+        let desired_vip = (*state as usize) & 0xff;
+        let old_vip = gintc::read().vip();
+        if old_vip != desired_vip {
+            gintc::write_vip(desired_vip);
+        }
     }
+    changed && cpu != this_cpu_id()
+}
+
+pub fn sync_guest_irqs() {
+    sync_guest_irqs_for_cpu(this_cpu_id(), |_| false);
 }
 
 pub fn set_guest_irq_line(cpu: usize, irq: usize, asserted: bool) -> bool {
@@ -142,23 +148,16 @@ pub fn set_guest_irq_line(cpu: usize, irq: usize, asserted: bool) -> bool {
     }
 
     let mask = 1u32 << (irq - INT_HWI0);
-    let need_remote_sync = {
-        let _guard = get_guest_hwi_lock(cpu).lock();
-        let state = &GUEST_HWI_ASSERTED[cpu];
-        let old = state.load(Ordering::Relaxed);
+    let need_remote_sync = sync_guest_irqs_for_cpu(cpu, |state| {
+        let old = *state;
         let new = if asserted { old | mask } else { old & !mask };
         if old == new {
             false
         } else {
-            state.store(new, Ordering::Relaxed);
-            if cpu == this_cpu_id() {
-                sync_guest_irqs_unlocked(cpu);
-                false
-            } else {
-                true
-            }
+            *state = new;
+            true
         }
-    };
+    });
     // Drop the lock before kicking the target; its handler takes the same lock.
     if need_remote_sync {
         send_event(cpu, SGI_IPI_ID as usize, IPI_EVENT_VIRTIO_INJECT_IRQ);
@@ -170,27 +169,14 @@ pub fn clear_guest_irq_lines(cpu: usize) {
     if cpu >= MAX_CPU_NUM {
         return;
     }
-    let need_remote_sync = {
-        let _guard = get_guest_hwi_lock(cpu).lock();
-        let old = GUEST_HWI_ASSERTED[cpu].swap(0, Ordering::Relaxed);
-        if old == 0 {
-            false
-        } else if cpu == this_cpu_id() {
-            sync_guest_irqs_unlocked(cpu);
-            false
-        } else {
-            true
-        }
-    };
+    let need_remote_sync = sync_guest_irqs_for_cpu(cpu, |state| {
+        let old = *state;
+        *state = 0;
+        old != 0
+    });
     if need_remote_sync {
         send_event(cpu, SGI_IPI_ID as usize, IPI_EVENT_VIRTIO_INJECT_IRQ);
     }
-}
-
-pub fn sync_guest_irqs() {
-    let cpu = this_cpu_id();
-    let _guard = get_guest_hwi_lock(cpu).lock();
-    sync_guest_irqs_unlocked(cpu);
 }
 
 /// inject irq to THIS cpu

--- a/src/device/virtio_trampoline.rs
+++ b/src/device/virtio_trampoline.rs
@@ -22,11 +22,11 @@
 
 #[cfg(not(target_arch = "loongarch64"))]
 use crate::device::irqchip::inject_irq;
-#[cfg(not(target_arch = "loongarch64"))]
 use crate::{
     arch::cpu::get_target_cpu,
     event::{send_event, IPI_EVENT_WAKEUP_VIRTIO_DEVICE},
     hypercall::SGI_IPI_ID,
+    platform::IRQ_WAKEUP_VIRTIO_DEVICE,
 };
 use crate::{
     arch::cpu::this_cpu_id, consts::MAX_WAIT_TIMES, error::HvResult, memory::MMIOAccess,
@@ -63,9 +63,6 @@ const MAX_PCI_DATA_REQ: usize = 32;
 pub const VIRTIO_PCI_HYPERCALL_VERSION: u16 = 1;
 
 pub const MAX_BACKOFF: usize = 1024;
-
-#[cfg(not(target_arch = "loongarch64"))]
-use crate::platform::IRQ_WAKEUP_VIRTIO_DEVICE;
 
 /// non root zone's virtio request handler
 pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
@@ -109,10 +106,8 @@ pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
     req_agent.push_req(hreq);
     drop(req_agent);
 
-    #[cfg(not(target_arch = "loongarch64"))]
     let mut is_ipi_sent = false;
     // If backend is sleep, hvisor needs to send ipi to wake it up.
-    #[cfg(not(target_arch = "loongarch64"))]
     check_need_wakeup_and_send_ipi(&mut is_ipi_sent);
 
     let mut count: usize = 0;
@@ -134,7 +129,6 @@ pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
                 );
                 count = 0;
             }
-            // check_need_wakeup_and_send_ipi(&mut is_ipi_sent);
         }
         if !mmio.is_write {
             // ensure cfg value is right.
@@ -146,7 +140,6 @@ pub fn mmio_virtio_handler(mmio: &mut MMIOAccess, base: usize) -> HvResult {
     Ok(())
 }
 
-#[cfg(not(target_arch = "loongarch64"))]
 pub fn check_need_wakeup_and_send_ipi(is_send_ipi: &mut bool) {
     if !(*is_send_ipi) && VIRTIO_BRIDGE.need_wakeup() {
         debug!("need wakeup (recheck), sending ipi to wake up virtio device");


### PR DESCRIPTION
## Summary

Fix excessive VirtIO backend CPU usage on LoongArch64.

- Enable VirtIO wakeup IPI for LoongArch64.
- Use CPUINTC IRQ 4 (HWI2), matching the device tree.
- Prevent repeated wakeups and HWI update races.
- Allow `hvisor-virtio` to sleep in `epoll_wait()` when idle.

Tested by building hvisor, hvisor-tool, and hvisor.ko for LoongArch64.